### PR TITLE
SessionTimeout errors in error log (#48)

### DIFF
--- a/node/risk-app/server/routes/search.js
+++ b/node/risk-app/server/routes/search.js
@@ -37,7 +37,7 @@ module.exports = [
         const captchaCheckResults = await captchaCheck('', postcode, request.yar)
 
         if (!captchaCheckResults.tokenValid) {
-          return boom.badRequest(errors.sessionTimeoutError.message)
+          return h.redirect('/postcode')
         }
 
         const addresses = await addressService.find(postcode)

--- a/node/risk-app/test/routes/search.js
+++ b/node/risk-app/test/routes/search.js
@@ -20,19 +20,28 @@ const createAddressStub = () => {
 }
 const createWarningStub = () => mock.replace(floodService, 'findWarnings', mock.makePromise(null, null))
 
-lab.experiment('Unit', () => {
-  let server, cookie
+lab.experiment('search page route', () => {
+  let server, cookie, addressStub, warningStub
 
   // Make a server before the tests
   lab.before(async () => {
     server = await createServer()
     await server.initialize()
-
     const initial = mockOptions()
 
     const homepageresponse = await server.inject(initial)
     Code.expect(homepageresponse.statusCode).to.equal(200)
     cookie = homepageresponse.headers['set-cookie'][0].split(';')[0]
+  })
+
+  lab.beforeEach(() => {
+    addressStub = createAddressStub()
+    warningStub = createWarningStub()
+  })
+
+  lab.afterEach(() => {
+    warningStub.revert()
+    addressStub.revert()
   })
 
   lab.after(async () => {
@@ -43,102 +52,71 @@ lab.experiment('Unit', () => {
   lab.test('/search - banner ', async () => {
     // This doesn't seem to actually test anything TODO: Check this test
     const { getOptions } = mockSearchOptions('cw8 4bh', cookie)
-
-    const addressStub = createAddressStub()
-    const warningStub = createWarningStub()
     const getResponse = await server.inject(getOptions)
     Code.expect(getResponse.statusCode).to.equal(200)
-    warningStub.revert()
-    addressStub.revert()
   })
 
   lab.test('/address - No banner warnings', async () => {
     // This doesn't seem to actually test anything TODO: Check this test
     const { getOptions } = mockSearchOptions('cw8 4bh', cookie)
-
-    const addressStub = createAddressStub()
-    const warningStub = createWarningStub()
     const getResponse = await server.inject(getOptions)
     Code.expect(getResponse.statusCode).to.equal(200)
-    warningStub.revert()
-    addressStub.revert()
   })
 
   lab.test('/search - No warning banner severity', async () => {
     // This doesn't seem to actually test anything TODO: Check this test
     const { getOptions } = mockSearchOptions('cw8 4bh', cookie)
-
-    const stub = mock.replace(floodService, 'findWarnings', mock.makePromise(null, {
+    const floodServiceStub = mock.replace(floodService, 'findWarnings', mock.makePromise(null, {
       message: 'There is currently one flood alert in force at this location.'
     }))
-    const addressStub = createAddressStub()
-
     const getResponse = await server.inject(getOptions)
     Code.expect(getResponse.statusCode).to.equal(200)
-    stub.revert()
-    addressStub.revert()
+    floodServiceStub.revert()
   })
 
   lab.test('/search - With banner warnings', async () => {
     const { getOptions } = mockSearchOptions('cw8 4bh', cookie)
 
     const data = require('../data/banner-1.json')
-    const stub = mock.replace(floodService, 'findWarnings', mock.makePromise(null, data))
-    const addressStub = createAddressStub()
-
+    const floodServiceStub = mock.replace(floodService, 'findWarnings', mock.makePromise(null, data))
     const getResponse = await server.inject(getOptions)
     Code.expect(getResponse.statusCode).to.equal(200)
     await payloadMatchTest(getResponse.payload, /There is currently one flood alert in force at this location/g)
-    stub.revert()
-    addressStub.revert()
+    floodServiceStub.revert()
   })
 
   lab.test('/search - With banner alerts', async () => {
     const { getOptions } = mockSearchOptions('cw8 4bh', cookie)
-
     const data = require('../data/banner-2.json')
-    const stub = mock.replace(floodService, 'findWarnings', mock.makePromise(null, data))
-    const addressStub = createAddressStub()
-
+    const floodServiceStub = mock.replace(floodService, 'findWarnings', mock.makePromise(null, data))
     const getResponse = await server.inject(getOptions)
     Code.expect(getResponse.statusCode).to.equal(200)
     await payloadMatchTest(getResponse.payload, /There is currently one flood alert in force at this location/g)
-    stub.revert()
-    addressStub.revert()
+    floodServiceStub.revert()
   })
 
   lab.test('/search - Error', async () => {
     const { getOptions } = mockSearchOptions('cw8 4bh', cookie)
-
-    const stub = mock.replace(floodService, 'findWarnings', mock.makePromise(() => { throw new Error('An error') }))
-    const addressStub = createAddressStub()
+    const floodServiceStub = mock.replace(floodService, 'findWarnings', mock.makePromise(() => { throw new Error('An error') }))
     const oldNotify = server.methods.notify
     let notifyCalled = false
     const newNotify = () => { notifyCalled = true }
     server.methods.notify = newNotify
-
     const getResponse = await server.inject(getOptions)
     Code.expect(getResponse.statusCode).to.equal(200)
     Code.expect(notifyCalled).to.equal(true)
     server.methods.notify = oldNotify
-    stub.revert()
-    addressStub.revert()
+    floodServiceStub.revert()
   })
 
   lab.test('/search', async () => {
     const { getOptions } = mockSearchOptions('cw8 4bh', cookie)
-    const addressStub = createAddressStub()
-    const warningStub = createWarningStub()
-
     const getResponse = await server.inject(getOptions)
     Code.expect(getResponse.statusCode).to.equal(200)
-    warningStub.revert()
-    addressStub.revert()
   })
 
   lab.test('/search - Invalid postcode - fails regexp', async () => {
     const { getOptions } = mockSearchOptions('invalid', cookie)
-
     const getResponse = await server.inject(getOptions)
     Code.expect(getResponse.statusCode).to.equal(400)
   })
@@ -150,7 +128,6 @@ lab.experiment('Unit', () => {
       headers: { cookie }
     }
     const captchastub = mock.replace(captchaCheck, 'captchaCheck', mock.makePromise(null, mockCaptchaCheck('foo')))
-
     const response = await server.inject(options)
     Code.expect(response.statusCode).to.equal(400)
     captchastub.revert()
@@ -158,49 +135,32 @@ lab.experiment('Unit', () => {
 
   lab.test('/search - Invalid postcode - passes regexp', async () => {
     const { getOptions } = mockSearchOptions('XX11 1XX', cookie)
-    const addressStub = createAddressStub()
-    const warningStub = createWarningStub()
     const getResponse = await server.inject(getOptions)
     Code.expect(getResponse.statusCode).to.equal(200)
-    warningStub.revert()
-    addressStub.revert()
   })
 
   lab.test('/search - Address service error', async () => {
     const { getOptions } = mockSearchOptions('cw8 4bh', cookie)
-    const addressStub = mock.replace(addressService, 'find', mock.makePromise('Mock Address Error'))
-    const warningStub = createWarningStub()
-
+    const customAddressStub = mock.replace(addressService, 'find', mock.makePromise('Mock Address Error'))
     const getResponse = await server.inject(getOptions)
     Code.expect(getResponse.statusCode).to.equal(400)
-    warningStub.revert()
-    addressStub.revert()
+    customAddressStub.revert()
   })
 
   lab.test('/search - Address service returns empty address array', async () => {
     const { getOptions } = mockSearchOptions('cw8 4bh', cookie)
-
-    const addressStub = mock.replace(addressService, 'find', mock.makePromise(null, []))
-    const warningStub = createWarningStub()
-
+    const customAddressStub = mock.replace(addressService, 'find', mock.makePromise(null, []))
     const getResponse = await server.inject(getOptions)
     Code.expect(getResponse.statusCode).to.equal(200)
-    warningStub.revert()
-    addressStub.revert()
+    customAddressStub.revert()
   })
 
   lab.test('/search - NATIONAL address to continue as normal', async () => {
     const { getOptions } = mockSearchOptions('cw8 4bh', cookie)
-
     const captchastub = mock.replace(utils, 'post', mock.makePromise(null, mockCaptchaResponse(true, null)))
-    const addressStub = createAddressStub()
-    const warningStub = createWarningStub()
-
     const getResponse = await server.inject(getOptions)
     Code.expect(getResponse.statusCode).to.equal(200)
     captchastub.revert()
-    addressStub.revert()
-    warningStub.revert()
   })
 
   lab.test('/search - NI address to redirect to england-only', async () => {
@@ -221,14 +181,9 @@ lab.experiment('Unit', () => {
       payload: { postcode: 'CW8 4BH', a: 'b' }
     }
     const captchastub = mock.replace(utils, 'post', mock.makePromise(null, mockCaptchaResponse(true, null)))
-    const addressStub = createAddressStub()
-    const warningStub = createWarningStub()
-
     const response = await server.inject(options)
     Code.expect(response.statusCode).to.equal(302)
     captchastub.revert()
-    addressStub.revert()
-    warningStub.revert()
   })
 
   lab.test('400 for missing expected query parameter', async () => {
@@ -239,5 +194,19 @@ lab.experiment('Unit', () => {
 
     const response = await server.inject(options)
     Code.expect(response.statusCode).to.equal(400)
+  })
+
+  lab.test('should redirect user to postcode page if captcha times out or not found', async () => {
+    const captchastub = mock.replace(utils, 'post', mock.makePromise(null, mockCaptchaResponse(true, null)))
+    const responseUrl = await server.inject(mockSearchOptions('cw8 4bh').getOptions)
+    Code.expect(responseUrl.statusCode).to.equal(302)
+    captchastub.revert()
+  })
+
+  lab.test('should get search page with postcode if already queried and captcha not expired', async () => {
+    const captchastub = mock.replace(utils, 'post', mock.makePromise(null, mockCaptchaResponse(true, null)))
+    const responseUrl = await server.inject(mockSearchOptions('cw8 4bh', cookie).getOptions)
+    Code.expect(responseUrl.statusCode).to.equal(200)
+    captchastub.revert()
   })
 })


### PR DESCRIPTION
* SessionTimeout errors in error log

https://eaflood.atlassian.net/browse/LTFRI-712

When people bookmark the URL http://check-long-term-flood-risk.service.gov.uk/search?postcode=xxxx&token=xxxx an errbit timeout error appears. This needs to be handled with a redirect and rerun the friendly captcha.