### PR TITLE
Change focus order for Map copyright note

### DIFF
--- a/node/risk-app/server/views/map.html
+++ b/node/risk-app/server/views/map.html
@@ -48,9 +48,9 @@
   <div class="map-container">
     <div id="progress"></div>
     <div id="map">
-      <div class="os-api-branding logo"></div>
-      <div class="os-api-branding copyright"><a href="/os-terms">Contains OS data &#169; Crown copyright and database rights {{year}}</a></div>
     </div>
+    <div class="os-api-branding logo"></div>
+    <div class="os-api-branding copyright"><a href="/os-terms">Contains OS data &#169; Crown copyright and database rights {{year}}</a></div>
     <div id="map-overlay" tabindex="-1">
       <div class="map-overlay-container">
         <button class="map-overlay-close" title="Close flood risk overlay notification" aria-label="Close flood risk overlay notification">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-696

When cycling using keyboard only users are taked to the copyright section of the map before more important parts. This should be a lower order of focus.