### PR TITLE
Screen readers do not pick up status messaged added to page

### DIFF
--- a/node/risk-app/server/views/map.html
+++ b/node/risk-app/server/views/map.html
@@ -44,7 +44,7 @@
       </div>
     </div>
   </div>
-  <div id="error-message" class="govuk-body-s govuk-!-margin-bottom-0 govuk-!-margin-top-1"></div>
+  <div id="error-message" role="status" class="govuk-body-s govuk-!-margin-bottom-0 govuk-!-margin-top-1"></div>
   <div class="map-container">
     <div id="progress"></div>
     <div id="map">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-680

When status messages appear on the map page the users that use assistive technology should be aware of them.