### PR TITLE
Update HTML tags to include IDs for testing dynamic content - R&S

### DIFF
--- a/node/risk-app/server/views/partials/rivers-sea.html
+++ b/node/risk-app/server/views/partials/rivers-sea.html
@@ -1,41 +1,41 @@
 <!-- Rivers and seas -->
-<div class="govuk-summary-card rivers-sea">
-  <div class="govuk-summary-card__title-wrapper {{ riverAndSeaClassName }}">
-    <h2 class="govuk-summary-card__title">Rivers and the sea<span class="chance-content risk">{{ riversAndSeaTitle }} of
+<div class="govuk-summary-card rivers-and-sea">
+  <div class="govuk-summary-card__title-wrapper rivers-and-sea" id="rivers-and-seas-{{ riverAndSeaClassName }}">
+    <h2 class="govuk-summary-card__title rivers-and-sea">Rivers and the sea<span class="chance-content risk rivers-and-sea" id="rivers-and-seas-{{ riverAndSeaClassName }}-title">{{ riversAndSeaTitle }} of
         flooding</span>
     </h2>
   </div>
-  <div class="govuk-summary-card__content">
-    <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
+  <div class="govuk-summary-card__content rivers-and-sea">
+    <dl class="govuk-summary-list rivers-and-sea">
+      <div class="govuk-summary-list__row rivers-and-sea">
+        <dt class="govuk-summary-list__key rivers-sea-dt-title" id="likeliness-rivers-and-seas">
           How likely a flood is
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd class="govuk-summary-list__value rivers-and-sea" id="likeliness-rivers-and-seas-{{ riverAndSeaClassName }}-desc">
           {% if riversAndSeaTextName %}
           {% include riversAndSeaTextName %}
           {% endif %}
           <br><br>
         </dd>
       </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
+      <div class="govuk-summary-list__row rivers-and-sea">
+        <dt class="govuk-summary-list__key rivers-sea-dt-title" id="managing-rivers-and-seas">
           Manage your flood risk from rivers and the sea
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd class="govuk-summary-list__value rivers-and-sea" id="managing-rivers-and-seas-{{ riverAndSeaClassName }}-risk-desc">
           {% if (riversAndSeaTitle !== 'Very low risk') %}
           An area can still be at risk of flooding even if it has not flooded in the past.
           <br><br>
           You should check your long term flood risk regularly because the information may change. You can also:
-          <ul class="govuk-list--bullet">
+          <ul class="govuk-list--bullet rivers-and-sea">
             <li>
-              <a class="govuk-link" href="https://www.gov.uk/sign-up-for-flood-warnings"
+              <a class="govuk-link rivers-and-sea" href="https://www.gov.uk/sign-up-for-flood-warnings"
                 data-journey-click="ltfri:risk:managing-flood-risk">
                 sign up to receive flood warnings by phone, text or email
               </a>
             </li>
             <li>find out what you can do to
-              <a class="govuk-link" href="https://www.gov.uk/prepare-for-flooding"
+              <a class="govuk-link rivers-and-sea" href="https://www.gov.uk/prepare-for-flooding"
                 data-journey-click="ltfri:risk:managing-flood-risk">
                 prepare for flooding
               </a>
@@ -46,39 +46,39 @@
           You should check your long term flood risk regularly because the information may change.  
           <br><br>
           You can also find out
-          <a class="govuk-link" href="https://www.gov.uk/prepare-for-flooding" 
+          <a class="govuk-link rivers-and-sea" href="https://www.gov.uk/prepare-for-flooding" 
             data-journey-click="ltfri:risk:managing-flood-risk">
             how to prepare for flooding
           </a>
           .
           {% else %}
-          You should check your long term flood risk regularly because the information may change.  
+          <span id="managing-{{ riverAndSeaClassName }}-rivers-and-seas-risk-text">You should check your long term flood risk regularly because the information may change.</span>
           {% endif %}
         </dd>
       </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
+      <div class="govuk-summary-list__row rivers-and-sea">
+        <dt class="govuk-summary-list__key rivers-sea-dt-title" id="info-covers-rivers-and-seas">
           What this information covers
         </dt>
-        <dd class="govuk-summary-list__value">
+        <dd class="govuk-summary-list__value rivers-and-sea" id="info-covers-rivers-and-seas-{{ riverAndSeaClassName }}-desc">
           This information is not specific to a property.
           <br><br>
           The information takes into account any flood defences. They can help reduce the chance of flooding but cannot
           completely prevent it because:
-          <ul class="govuk-list--bullet">
+          <ul class="govuk-list--bullet rivers-and-sea">
             <li>they can fail</li>
             <li>water could spill over the top if it is deep enough</li>
           </ul>
           {% if (riversAndSeaTitle !== 'Very low risk') %}
-          <details class="govuk-details" data-module="govuk-details">
-            <summary class="govuk-details__summary" data-journey-click="ltfri:risk:managing-rivers-and-sea-details">
-              <span class="govuk-details__summary-text">
+          <details class="govuk-details rivers-and-sea" data-module="govuk-details" id="info-covers-rivers-and-seas-dropdown">
+            <summary class="govuk-details__summary rivers-and-sea" data-journey-click="ltfri:risk:managing-rivers-and-sea-details">
+              <span class="govuk-details__summary-text rivers-and-sea">
                 What you can use this information for
               </span>
             </summary>
-            <div class="govuk-details__text">
+            <div class="govuk-details__text rivers-and-sea">
               This information is suitable for identifying:
-              <ul class="govuk-list--bullet">
+              <ul class="govuk-list--bullet rivers-and-sea">
                 <li>which parts of countries or counties are at risk, or have the most risk</li>
                 <li>the approximate extent and depth of flooding</li>
               </ul>
@@ -91,13 +91,13 @@
           {% endif %}
         </dd>
       </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
+      <div class="govuk-summary-list__row rivers-and-sea">
+        <dt class="govuk-summary-list__key rivers-sea-dt-title" id="see-map-rivers-and-seas">
           See rivers and sea flood risk on a map
         </dt>
-        <dd class="govuk-summary-list__value">
-          <p class="govuk-!-margin-bottom-3">
-            <a class="govuk-link" href="/map?easting={{easting}}&northing={{northing}}&map=RiversOrSea"
+        <dd class="govuk-summary-list__value rivers-and-sea" id="see-map-{{ riverAndSeaClassName }}-rivers-and-seas-desc">
+          <p class="govuk-!-margin-bottom-3 rivers-and-sea">
+            <a class="govuk-link rivers-and-sea" href="/map?easting={{easting}}&northing={{northing}}&map=RiversOrSea"
               data-journey-click="ltfri:risk:managing-flood-risk">
               View a map of flood risk from rivers and the sea
             </a>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-883

Following a meeting with Chris, he advised that the tests are more complicated than they could be. This is due to the dynamic content not have unique references to narrow down the tests. He has suggest we add IDs to the dynamic content in order to increase reliability of the tests.