### PR TITLE
Remove Focus indicator on Exit button in map page

### DIFF
--- a/node/risk-app/server/views/map.html
+++ b/node/risk-app/server/views/map.html
@@ -15,7 +15,10 @@
 <link href="{{ assetPath }}/stylesheets/map-page.css" rel="stylesheet" />
 {% endblock %}
 
+
 {% block bodyStart %}
+{% block skipLink %}
+{% endblock %}
 <style>
   body {
     margin: 0;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-888

When the user is on the map page, the first focus received using the keyboard should be the Exit button. The default Skip to main content hyperlink focus should be removed.