### PR TITLE
Avoid overlapping of zoom in and zoom out buttons on the map

### DIFF
--- a/node/risk-app/client/sass/map-page.scss
+++ b/node/risk-app/client/sass/map-page.scss
@@ -195,6 +195,10 @@ $govuk-assets-path: '/assets/';
   border-radius: 0;
 }
 
+.ol-zoom .ol-zoom-in:focus {
+  z-index: 12;
+}
+
 .ol-zoom .ol-zoom-in button:hover {
   background-color: #f3f2f1;
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-907

Fix the zoom button focus so it does not go behind the zoom out button when focused.