### PR TITLE
Update key to reflect options equivalent to the flood type link it has come from

### DIFF
--- a/node/risk-app/server/public/static/js/map-page.js
+++ b/node/risk-app/server/public/static/js/map-page.js
@@ -51,6 +51,7 @@ function mapPage () {
   }
   const mapController = new MapController(mapCategories.categories)
   const $header = $('.govuk-radios')
+  const $advancedHeader = $('.defra-map-controls')
   const $map = $('#map')
   const $body = $(document.body)
 
@@ -93,6 +94,11 @@ function mapPage () {
       e.preventDefault()
       setCurrent($(this).val())
     })
+    $advancedHeader.on('click', '#advanced-key-button', function (e) {
+      toggleAdvancedOptions()
+      e.preventDefault()
+      setCurrent($(this).val())
+    })
 
     setCurrent(getParameterByName('map'))
   })
@@ -113,6 +119,7 @@ function getInitialKeyOptions () {
   const extentInfoRs = document.getElementById('rs-extent-desc-container')
   const extentInfoReservoirs = document.getElementById('reservoirs-extent-desc-container')
   const boundaryContainer = document.getElementById('boundary-container')
+  const extentInfoSw = document.getElementById('sw-extent-desc-container')
 
   if (window.location.href.includes('map=SurfaceWater')) {
     velocityContainer.style.display = 'none'
@@ -121,6 +128,7 @@ function getInitialKeyOptions () {
   }
   if (window.location.href.includes('map=RiversOrSea')) {
     swContainer.style.display = 'none'
+    extentInfoSw.style.display = 'none'
     rsContainer.style.display = 'block'
     rsContainer.style.marginTop = '40px'
     rsRadio.checked = true
@@ -130,6 +138,7 @@ function getInitialKeyOptions () {
   }
   if (window.location.href.includes('map=Reservoirs')) {
     swContainer.style.display = 'none'
+    extentInfoSw.style.display = 'none'
     rsContainer.style.display = 'none'
     reservoirsContainer.style.display = 'block'
     reservoirsContainer.style.marginTop = '40px'
@@ -254,11 +263,55 @@ function toggleCopyrightInfo () {
 
 /* eslint-disable no-unused-vars */
 function toggleAdvancedOptions () {
-  const advancedMapOptions = document.getElementsByClassName('advanced-map-option')
-  if (!advancedMapOptions[0].classList.contains('showing')) {
-    advancedMapOptions[0].style.display = 'block'
+  const advancedButtonText = document.getElementById('advanced-button-text')
+  const advancedButtonImage = document.getElementById('advanced-button-image')
+  const velocityContainer = document.getElementById('sw-velocity-section-container')
+  const swContainer = document.getElementById('sw-section-container')
+  const rsContainer = document.getElementById('rs-section-container')
+  const reservoirsContainer = document.getElementById('reservoirs-section-container')
+  const swExtentRadio = document.getElementById('sw-extent-radio')
+  const rsExtentRadio = document.getElementById('rs-radio')
+  const reservoirsRadio = document.getElementById('reservoirs-radio')
+
+  if (advancedButtonText.textContent.includes('Show')) {
+    advancedButtonText.textContent = 'Hide advanced options'
+    advancedButtonImage.setAttribute('d', 'M20.515 15.126 12 19.856l-8.515-4.73-.971 1.748 9 5a1 1 0 0 0 .971 0l9-5zM16 4h6v2h-6zm5.484 7.125-9.022-5a1 1 0 0 0-.968-.001l-8.978 4.96a1 1 0 0 0-.003 1.749l9.022 5.04a.995.995 0 0 0 .973.001l8.978-5a1 1 0 0 0-.002-1.749z')
+    velocityContainer.style.display = 'block'
+    swContainer.style.display = 'block'
+    rsContainer.style.display = 'block'
+    rsContainer.style.marginTop = '0px'
+    reservoirsContainer.style.marginTop = '0px'
+    reservoirsContainer.style.display = 'block'
   } else {
-    advancedMapOptions[0].style.display = 'none'
+    if (window.location.href.includes('map=SurfaceWater')) {
+      swContainer.style.display = 'block'
+      velocityContainer.style.display = 'none'
+      rsContainer.style.display = 'none'
+      reservoirsContainer.style.display = 'none'
+      swExtentRadio.checked = true
+      handleRadioChange('extent', 'surface water')
+    }
+    if (window.location.href.includes('map=RiversOrSea')) {
+      swContainer.style.display = 'none'
+      velocityContainer.style.display = 'none'
+      rsContainer.style.display = 'block'
+      reservoirsContainer.style.marginTop = '40px'
+      rsExtentRadio.checked = true
+      reservoirsContainer.style.display = 'none'
+      handleRadioChange('extent', 'rivers and the sea')
+    }
+    if (window.location.href.includes('map=Reservoirs')) {
+      swContainer.style.display = 'none'
+      velocityContainer.style.display = 'none'
+      rsContainer.style.display = 'none'
+      reservoirsContainer.style.display = 'block'
+      reservoirsContainer.style.marginTop = '40px'
+      reservoirsRadio.checked = true
+      handleRadioChange('extent', 'reservoirs')
+    }
+    selectedOption()
+    advancedButtonText.textContent = 'Show advanced options'
+    advancedButtonImage.setAttribute('d', 'm3.485 15.126-.971 1.748 9 5a1 1 0 0 0 .971 0l9-5-.971-1.748L12 19.856ZM20 8V6h2V4h-2V2h-2v2h-2v2h2v2zM2.513 12.833l9.022 5.04a.995.995 0 0 0 .973.001l8.978-5a1 1 0 0 0-.002-1.749l-9.022-5a1 1 0 0 0-.968-.001l-8.978 4.96a1 1 0 0 0-.003 1.749z')
   }
 }
 /* eslint-enable no-unused-vars */

--- a/node/risk-app/server/views/map.html
+++ b/node/risk-app/server/views/map.html
@@ -48,15 +48,13 @@
     </button>
 
     <!-- Advanced options button -->
-    <button class="defra-map__advanced" id="advanced-map-button" tabindex="1" style="color:	#0b0c0c;"
-      onclick="toggleAdvancedOptions()">
-      <svg viewBox="0 0 24 24" height="24" width="24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
-        focusable="false">
-        <path
-          d="M20.515 15.126 12 19.856l-8.515-4.73-.971 1.748 9 5a1 1 0 0 0 .971 0l9-5zM16 4h6v2h-6zm5.484 7.125-9.022-5a1 1 0 0 0-.968-.001l-8.978 4.96a1 1 0 0 0-.003 1.749l9.022 5.04a.995.995 0 0 0 .973.001l8.978-5a1 1 0 0 0-.002-1.749z">
+    <button class="defra-map__advanced" id="advanced-key-button" tabindex="1" style="color:	#0b0c0c;">
+      <svg viewBox="0 0 24 24" height="24" width="24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+        <path id="advanced-button-image"
+          d="m3.485 15.126-.971 1.748 9 5a1 1 0 0 0 .971 0l9-5-.971-1.748L12 19.856ZM20 8V6h2V4h-2V2h-2v2h-2v2h2v2zM2.513 12.833l9.022 5.04a.995.995 0 0 0 .973.001l8.978-5a1 1 0 0 0-.002-1.749l-9.022-5a1 1 0 0 0-.968-.001l-8.978 4.96a1 1 0 0 0-.003 1.749z">
         </path>
       </svg>
-      <span id="map-button-text">Hide advanced options</span>
+      <span id="advanced-button-text">Show advanced options</span>
     </button>
 
     <div class="defra-map-controls-bottom">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-932

When a user follows a link for viewing a map from either the surface water, rivers and the sea or reservoirs links, they should be taken to the map showing the associated options on entering the page.