### PR TITLE
Remove invisible checkbox from key

### DIFF
--- a/node/risk-app/server/views/map.html
+++ b/node/risk-app/server/views/map.html
@@ -501,9 +501,6 @@
                     </span>
                   </label>
                 </div>
-                <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" id="tech-option" name="map-toggle" type="checkbox" value="40">
-                </div>
               </div>
             </fieldset>
           </div>


### PR DESCRIPTION
When going through accessibility checks, an invisible checkbox was noted as being usable. This needs to be removed.