### PR TITLE
Scenario bar appears behind the key on ipad mini

### DIFF
--- a/node/risk-app/client/sass/map-page.scss
+++ b/node/risk-app/client/sass/map-page.scss
@@ -30,7 +30,7 @@ $scenarioWidthCap: 980px;
   #map-key {
     display: block;
 
-    @media screen and (min-width: $tablet-width) {
+    @media screen and (min-width: $desktop-width) {
       display: block !important;
     }
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1025

When on the ipad mini the scenario bar appears behind the key when it should not.