### PR TITLE
Surface Water Extent 15m yellow radius is not disappearing

### DIFF
--- a/node/risk-app/server/public/static/js/map.js
+++ b/node/risk-app/server/public/static/js/map.js
@@ -250,7 +250,7 @@ function showMap (layerReference, hasLocation) {
       if (className === 'pointMarker' && hasLocation) {
         layer.setVisible(true)
         layer.setZIndex(1)
-      } else if (className === 'radiusMarker' && layerReference.substr(7, 2) === 'SW') {
+      } else if (className === 'radiusMarker' && hasLocation && layerReference.substr(7, 2) === 'SW') {
         layer.setVisible(true)
         layer.setZIndex(0)
       } else {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1068

When a user clicks the tickbox to turn off the pointer icon and yellow border radius for the found location, the yellow border does not disappear when it should.