### PR TITLE
Add a better description of the holding comment option button

### DIFF
--- a/node/risk-admin/server/views/home.html
+++ b/node/risk-admin/server/views/home.html
@@ -19,12 +19,12 @@
     <h3 class="govuk-heading-s govuk-!-margin-bottom-2">PSO users (area teams)</h3>
     <ul class="govuk-list govuk-list--spaced">
       <li>Select this option to add local information</li>
-      <li><a class="govuk-button govuk-!-margin-bottom-2" href="/comment/create/holding">Create holding comment</a></li>
+      <li><a class="govuk-button govuk-!-margin-bottom-3" href="/comment/create/holding">Create holding comment</a></li>
     </ul>
     <h3 class="govuk-heading-s govuk-!-margin-bottom-2">National teams</h3>
-    <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-2">
+    <ul class="govuk-list govuk-list--spaced">
       <li>Select this option to add non-modelled surface water information</li>
-      <li><a href="/comment/create/llfa" class="govuk-button">Create LLFA comment</a></li>
+      <li><a class="govuk-button" href="/comment/create/llfa" >Create LLFA comment</a></li>
     </ul>
     <p class="govuk-body"><a href="/comments.csv" download>Download all comments</a></p>
   </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1019

If an internal user is using the management console to add a holding comment, its not clear what a PSO comment is and the description doesn’t help a user understand what it could be used for. Changes should be made to make it easier for a user to understand what this option means.