### PR TITLE
Map focus states only show on tab focus

### DIFF
--- a/node/risk-app/client/sass/map-page.scss
+++ b/node/risk-app/client/sass/map-page.scss
@@ -154,11 +154,6 @@ $gov-font: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
     outline: 3px solid transparent;
     box-shadow: 0px 0px 0px 2px white, inset 0px 0px 0px 0px #0b0c0c, 0px 0px 0px 5px #0b0c0c, 0px 0px 0px 8px #ffdd00;
   }
-  .defra-map__open-key:focus[keyboard-focus]:after {
-    /* @include focus; */
-    outline: 3px solid transparent;
-    box-shadow: 0px 0px 0px 2px white, inset 0px 0px 0px 0px #0b0c0c, 0px 0px 0px 5px #0b0c0c, 0px 0px 0px 8px #ffdd00;
-  }
   .defra-map__open-key::-moz-focus-inner {
     border: 0;
   }
@@ -224,7 +219,7 @@ $gov-font: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
         cursor: pointer;
       }
 
-      &:focus {
+      &:focus-visible {
         outline: 3px solid transparent;
         box-shadow: 0px 0px 0px 2px white, inset 0px 0px 0px 0px #0b0c0c, 0px 0px 0px 5px #0b0c0c, 0px 0px 0px 8px #ffdd00;
       }
@@ -284,7 +279,7 @@ $gov-font: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
         background-color: #f3f2f1;
       }    
 
-      button:focus {
+      button:focus-visible {
         outline: 3px solid transparent;
         box-shadow: 0px 0px 0px 2px white, inset 0px 0px 0px 0px #0b0c0c, 0px 0px 0px 5px #0b0c0c, 0px 0px 0px 8px #ffdd00;
       }
@@ -357,8 +352,9 @@ $gov-font: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
   .defra-map__exit:hover {
     background-color: #f3f2f1;
   }
-  .defra-map__exit:focus {
-    outline: none;
+  .defra-map__exit:focus-visible {
+    outline: 3px solid transparent;
+    box-shadow: 0px 0px 0px 2px white, inset 0px 0px 0px 0px #0b0c0c, 0px 0px 0px 5px #0b0c0c, 0px 0px 0px 8px #ffdd00;
   }
   .defra-map__exit:focus[keyboard-focus]:after {
     position: absolute;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1041

It would be better if when a user clicks a button on the map it doesn’t show the outline/box shadow. 