### PR TITLE
Bugfix: Copyright text appears below scenario bar

### DIFF
--- a/node/risk-app/server/public/static/js/map-page.js
+++ b/node/risk-app/server/public/static/js/map-page.js
@@ -293,6 +293,10 @@ function handleRadioChange (selected, type) {
     if (window.innerWidth <= deviceScreenWidth && keyDisplay.style.display === 'block') {
       scenariosSelectorVelocity.style.display = 'none'
     }
+    if (window.innerWidth <= deviceScreenWidth) {
+      bottomCopyrightContainer.classList.add('hide')
+      topCopyrightContainer.classList.remove('hide')
+    }
     olZoom[0].style.top = 'calc(100% - 200px)'
   }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1078

When click on velocity when on a device and coming off the key, the copyright text appears below the scenario bar.