### PR TITLE
Show Advanced Options button text disappears on mobile devices

### DIFF
--- a/node/risk-app/client/sass/map-page.scss
+++ b/node/risk-app/client/sass/map-page.scss
@@ -11,7 +11,6 @@ $desktop-width: 769px;
 $scenarioWidthCap1: 1090px;
 $scenarioWidthCap2: 920px;
 $scenarioArrowPoint: 640px;
-$advancedToggleCutoff: 510px;
 
 $gov-font: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
 
@@ -457,14 +456,6 @@ $gov-font: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
   -moz-user-select: none;
   -ms-user-select: none;
   pointer-events: auto;
-
-  @media screen and (max-width: $advancedToggleCutoff) {
-    padding: 0;
-
-    span {
-      display: none;
-    }
-  }
 }
 .defra-map__advanced svg {
   display: inline-block;

--- a/node/risk-app/client/sass/map-page.scss
+++ b/node/risk-app/client/sass/map-page.scss
@@ -11,6 +11,7 @@ $desktop-width: 769px;
 $scenarioWidthCap1: 1090px;
 $scenarioWidthCap2: 920px;
 $scenarioArrowPoint: 640px;
+$advancedToggleCutoff: 510px;
 
 $gov-font: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
 
@@ -456,6 +457,14 @@ $gov-font: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
   -moz-user-select: none;
   -ms-user-select: none;
   pointer-events: auto;
+
+  @media screen and (max-width: $advancedToggleCutoff) {
+    padding: 0;
+
+    span {
+      display: none;
+    }
+  }
 }
 .defra-map__advanced svg {
   display: inline-block;

--- a/node/risk-app/server/public/static/js/map-page.js
+++ b/node/risk-app/server/public/static/js/map-page.js
@@ -127,6 +127,8 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     })
   })
+
+  showOrHideAdvancedToggleText()
 })
 
 handleArrowClick(rightArrow, rightMove)
@@ -142,12 +144,6 @@ function handleArrowClick (arrows, scrollDirection) {
       scenarioSelectionVelocity.scrollBy({ top: 0, left: scrollDirection, behavior: 'smooth' })
     })
   }
-}
-
-if (window.innerWidth <= advancedToggleCutoff && keyDisplay.style.display !== 'none') {
-  advancedToggleText.classList.add('hide')
-} else {
-  advancedToggleText.classList.remove('hide')
 }
 
 function handleScroll (scenarioBar, arrows) {

--- a/node/risk-app/server/public/static/js/map-page.js
+++ b/node/risk-app/server/public/static/js/map-page.js
@@ -102,9 +102,11 @@ const scenarioSelectionDepth = document.getElementById('scenario-selection-depth
 const scenarioSelectionVelocity = document.getElementById('scenario-selection-velocity')
 
 const advancedToggle = document.getElementById('advanced-key-button')
+const advancedToggleText = document.getElementById('advanced-button-text')
 const keyDisplay = document.getElementById('map-key')
 const openKeyBtn = document.getElementById('open-key')
 const deviceScreenWidth = 768
+const advancedToggleCutoff = 510
 const rightMove = 150
 const leftMove = -150
 
@@ -140,6 +142,12 @@ function handleArrowClick (arrows, scrollDirection) {
       scenarioSelectionVelocity.scrollBy({ top: 0, left: scrollDirection, behavior: 'smooth' })
     })
   }
+}
+
+if (window.innerWidth <= advancedToggleCutoff && keyDisplay.style.display === 'none') {
+  advancedToggleText.classList.add('hide')
+} else {
+  advancedToggleText.classList.remove('hide')
 }
 
 function handleScroll (scenarioBar, arrows) {

--- a/node/risk-app/server/public/static/js/map-page.js
+++ b/node/risk-app/server/public/static/js/map-page.js
@@ -144,7 +144,7 @@ function handleArrowClick (arrows, scrollDirection) {
   }
 }
 
-if (window.innerWidth <= advancedToggleCutoff && keyDisplay.style.display === 'none') {
+if (window.innerWidth <= advancedToggleCutoff && keyDisplay.style.display !== 'none') {
   advancedToggleText.classList.add('hide')
 } else {
   advancedToggleText.classList.remove('hide')
@@ -204,6 +204,7 @@ function toggleAdvancedOptions () {
   if (window.innerWidth <= deviceScreenWidth) {
     keyDisplay.style.display = 'block'
     scenarioSelectionDepth.style.display = 'none'
+    showOrHideAdvancedToggleText()
   }
 
   if (advancedButtonText.textContent.includes('Show')) {
@@ -253,6 +254,7 @@ function openKey () {
   openKeyBtn.style.display = 'none'
   scenarioSelectionDepth.style.display = 'none'
   scenarioSelectionVelocity.style.display = 'none'
+  showOrHideAdvancedToggleText()
 }
 
 function getInitialKeyOptions () {
@@ -482,6 +484,10 @@ function closeKey () {
   } else {
     osLogo.classList.remove('os-logo-position-change')
   }
+
+  if (window.innerWidth <= deviceScreenWidth) {
+    advancedToggleText.classList.remove('hide')
+  }
 }
 
 /* eslint-enable no-unused-vars */
@@ -536,6 +542,16 @@ function adjustPosition () {
   window.innerWidth <= deviceScreenWidth
   ) {
     zoomBtns[0].style.top = 'calc(100% - 200px)'
+  }
+  showOrHideAdvancedToggleText()
+}
+
+function showOrHideAdvancedToggleText () {
+  if (window.innerWidth <= deviceScreenWidth) {
+    advancedToggleText.classList.remove('hide')
+  }
+  if (window.innerWidth <= advancedToggleCutoff && keyDisplay.style.display === 'block') {
+    advancedToggleText.classList.add('hide')
   }
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1067

When on a mobile device, if the key is open and reaches the advanced options button, the button should no longer have text within it.