### PR TITLE
Remove space between the word flooding and the full stop on rivers an…

### DIFF
--- a/node/risk-app/server/views/partials/rivers-sea.html
+++ b/node/risk-app/server/views/partials/rivers-sea.html
@@ -49,9 +49,8 @@
           You can also find out
           <a class="govuk-link rivers-and-sea" href="https://www.gov.uk/prepare-for-flooding" 
             data-journey-click="ltfri:risk:managing-flood-risk">
-            how to prepare for flooding
+            how to prepare for flooding.
           </a>
-          .
           {% endif %}
         </dd>
       </div>


### PR DESCRIPTION
…d sea summary page

https://eaflood.atlassian.net/browse/LTFRI-1138

This change removes the space between flood and the full stop in the rivers and sea summary page content