### PR TITLE
Disable zoom button

### DIFF
--- a/node/risk-app/client/sass/_map-controls.scss
+++ b/node/risk-app/client/sass/_map-controls.scss
@@ -360,6 +360,14 @@ $gov-font: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
     top: calc(100% - 102px);
     left: calc(100% - 340px);
   }
+
+  .zoom-disabled {
+    fill: #c7c7c7;
+    pointer-events: none;
+    cursor: auto;
+    outline: none;
+    box-shadow: none;
+  }
   
   .ol-zoom .ol-zoom-in:focus {
     /* Ensures the focus boarder overlaps the other zoom button rather than hides behind */

--- a/node/risk-app/server/src/js/map.js
+++ b/node/risk-app/server/src/js/map.js
@@ -275,6 +275,53 @@ export function showMap (layerReference, hasLocation) {
       layer.setZIndex(0)
     }
   })
+
+  // The below toggles whether the zoom buttons are disabled. They are placed within this function
+  // as the map object was not accessible outside of it.
+  const zoomControls = {
+    zoomIn: document.querySelector('.ol-zoom-in'),
+    zoomOut: document.querySelector('.ol-zoom-out')
+  }
+  const disableThresholds = {
+    zoomInMax: 8,
+    zoomInEnable: 10,
+    zoomOutMax: 2,
+    zoomOutEnable: 0
+  }
+
+  zoomControls.zoomIn.addEventListener('click', () => {
+    disableZoomIn()
+  })
+
+  zoomControls.zoomOut.addEventListener('click', () => {
+    disableZoomOut()
+  })
+
+  function disableZoomIn () {
+    if (map.getView().getZoom() >= disableThresholds.zoomInMax) {
+      zoomControls.zoomIn.classList.add('zoom-disabled')
+    }
+    if (map.getView().getZoom() > disableThresholds.zoomOutEnable) {
+      zoomControls.zoomOut.classList.remove('zoom-disabled')
+    }
+  }
+
+  function disableZoomOut () {
+    if (map.getView().getZoom() < disableThresholds.zoomOutMax) {
+      zoomControls.zoomOut.classList.add('zoom-disabled')
+    }
+    if (map.getView().getZoom() < disableThresholds.zoomInEnable) {
+      zoomControls.zoomIn.classList.remove('zoom-disabled')
+    }
+  }
+
+  function initialZoomState () {
+    const zoom = map.getView().getZoom()
+    zoomControls.zoomIn.classList.toggle('zoom-disabled', zoom >= 8)
+    zoomControls.zoomOut.classList.toggle('zoom-disabled', zoom <= 2)
+  }
+
+  initialZoomState()
 }
 
 export function updateSize () {

--- a/node/risk-app/server/src/js/map.js
+++ b/node/risk-app/server/src/js/map.js
@@ -288,6 +288,7 @@ export function showMap (layerReference, hasLocation) {
     zoomOutMax: 2,
     zoomOutEnable: 0
   }
+  const disableClass = 'zoom-disabled'
 
   zoomControls.zoomIn.addEventListener('click', () => {
     disableZoomIn()
@@ -299,26 +300,26 @@ export function showMap (layerReference, hasLocation) {
 
   function disableZoomIn () {
     if (map.getView().getZoom() >= disableThresholds.zoomInMax) {
-      zoomControls.zoomIn.classList.add('zoom-disabled')
+      zoomControls.zoomIn.classList.add(disableClass)
     }
     if (map.getView().getZoom() > disableThresholds.zoomOutEnable) {
-      zoomControls.zoomOut.classList.remove('zoom-disabled')
+      zoomControls.zoomOut.classList.remove(disableClass)
     }
   }
 
   function disableZoomOut () {
     if (map.getView().getZoom() < disableThresholds.zoomOutMax) {
-      zoomControls.zoomOut.classList.add('zoom-disabled')
+      zoomControls.zoomOut.classList.add(disableClass)
     }
     if (map.getView().getZoom() < disableThresholds.zoomInEnable) {
-      zoomControls.zoomIn.classList.remove('zoom-disabled')
+      zoomControls.zoomIn.classList.remove(disableClass)
     }
   }
 
   function initialZoomState () {
     const zoom = map.getView().getZoom()
-    zoomControls.zoomIn.classList.toggle('zoom-disabled', zoom >= 8)
-    zoomControls.zoomOut.classList.toggle('zoom-disabled', zoom <= 2)
+    zoomControls.zoomIn.classList.toggle(disableClass, zoom >= 8)
+    zoomControls.zoomOut.classList.toggle(disableClass, zoom <= 2)
   }
 
   initialZoomState()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-994

When a user has fully zoomed into the map the zoom in button should be disabled, therefore meaning the user is unable to continue trying to zoom in.