### PR TITLE
Designs for risk summary that don't include NaFRA2 data (#297)

### DIFF
--- a/node/risk-app/client/sass/rivers-and-sea.scss
+++ b/node/risk-app/client/sass/rivers-and-sea.scss
@@ -1,0 +1,43 @@
+.govuk-tag--High {
+  color: #2a0b06;
+  background-color: #f4cdc6;
+}
+.govuk-tag--Medium {
+  background-color: #FFDEBF;
+  color: #6e3619;
+}
+.govuk-tag--Low {
+  color: #594d00;
+  background-color: #fff7bf;
+}
+.govuk-tag--Very-Low {
+  color: #0c2d4a;
+  background-color: #CCE2D8;
+}
+
+.chance-content {
+  padding-left: 10px;
+  border-style: solid;
+  border-width: 0 0 0 1px;
+  border-color: #b1b4b6;
+  font-weight: normal;
+  margin-left: 10px;
+}
+
+.label-border {
+  outline: solid 3px #0b0c0c;
+}
+.label-mod {
+  padding: 8px 12px 8px 12px;
+  white-space: nowrap;
+}
+.risk-label-group {
+  margin-top: 10px;
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.card-title__font-size {
+  font-size: 22px;
+}

--- a/node/risk-app/server/__mocks__/config.js
+++ b/node/risk-app/server/__mocks__/config.js
@@ -3,6 +3,7 @@ const value = jest.requireActual('../config')
 value.redisCacheEnabled = false
 value.errbit.postErrors = false
 value.simulateAddressService = false
+value.riskPageFlag = false
 
 value.setConfigOptions = function (newValues) {
   Object.keys(newValues).forEach(function (key) {

--- a/node/risk-app/server/config.js
+++ b/node/risk-app/server/config.js
@@ -38,6 +38,7 @@ const schema = joi.object().keys({
   friendlyCaptchaUrl: joi.string().when('friendlyCaptchaEnabled', { is: true, then: joi.required() }),
   friendlyCaptchaBypass: joi.string().default(''),
   sessionTimeout: joi.number().default(10),
+  riskPageFlag: joi.boolean().default(false),
   errbit: joi.object().required().keys({
     postErrors: joi.boolean().required(),
     options: {

--- a/node/risk-app/server/models/errors.json
+++ b/node/risk-app/server/models/errors.json
@@ -20,6 +20,9 @@
   "osMapsProxy": {
     "message": "Ordnance survey maps proxy call failed"
   },
+  "pageNotAvailable": {
+    "message": "This page is currently unavailable"
+  },
   "riskProfile": {
     "message": "An error occurred finding the risk profile"
   },

--- a/node/risk-app/server/models/risk-view.js
+++ b/node/risk-app/server/models/risk-view.js
@@ -1,4 +1,5 @@
 const { capitaliseAddress } = require('../services/address.js')
+const config = require('../config.js')
 
 const RiskLevel = {
   VeryLow: 'Very Low',
@@ -23,55 +24,105 @@ const suitabilities = [
   'town to street'
 ]
 
-function RiskViewModel (risk, address, backLinkUri) {
+function riskViewModel (risk, address, backLinkUri) {
   const riverAndSeaRisk = risk.riverAndSeaRisk
     ? risk.riverAndSeaRisk.probabilityForBand
     : RiskLevel.VeryLow
   const surfaceWaterRisk = risk.surfaceWaterRisk || RiskLevel.VeryLow
-  const reservoirDryRisk = !!(risk.reservoirDryRisk && risk.reservoirDryRisk.length)
-  const reservoirWetRisk = !!(risk.reservoirWetRisk && risk.reservoirWetRisk.length)
+  const reservoirDryRisk = !!(risk.reservoirDryRisk?.length)
+  const reservoirWetRisk = !!(risk.reservoirWetRisk?.length)
   const reservoirRisk = reservoirDryRisk || reservoirWetRisk
 
   this.riverAndSeaRisk = riverAndSeaRisk
   this.surfaceWaterRisk = surfaceWaterRisk
   this.riverAndSeaClassName = riverAndSeaRisk.toLowerCase().replace(' ', '-')
   this.surfaceWaterClassName = surfaceWaterRisk.toLowerCase().replace(' ', '-')
+  this.riversSeaRiskStyle = riverAndSeaRisk.replace(/ /g, '-')
+  this.surfaceWaterStyle = surfaceWaterRisk.replace(/ /g, '-')
   this.reservoirRisk = reservoirRisk
   this.backLink = backLinkUri
 
   if (reservoirRisk) {
-    const reservoirs = []
-
-    const add = function (item) {
-      reservoirs.push({
-        name: item.reservoirName,
-        owner: item.undertaker,
-        authority: item.leadLocalFloodAuthority,
-        location: item.location,
-        riskDesignation: item.riskDesignation,
-        comments: item.comments
-      })
-    }
-
-    if (reservoirDryRisk) {
-      risk.reservoirDryRisk.forEach(add)
-    }
-
-    if (reservoirWetRisk) {
-      risk.reservoirWetRisk.forEach(function (item) {
-        const exists = !!reservoirs.find(r => r.location === item.location)
-
-        if (!exists) {
-          add(item)
-        }
-      })
-    }
-
-    this.reservoirs = reservoirs
+    processReservoirs.call(this, reservoirDryRisk, risk, reservoirWetRisk)
   }
 
   // River and sea suitability
-  const riverAndSeaSuitability = risk.riverAndSeaRisk && risk.riverAndSeaRisk.suitability
+  processSuitability.call(this, risk)
+
+  // Groundwater area
+  this.isGroundwaterArea = risk.isGroundwaterArea
+  this.extraInfo = risk.extraInfo
+
+  this.hasHoldingComments = false
+  this.hasLlfaComments = false
+
+  // Extra info
+  processExtraInfo.call(this, risk)
+
+  this.easting = address.x
+  this.northing = address.y
+  this.postcode = address.postcode
+  this.lines = address.address.split(', ')
+  this.address = address
+  this.fullAddress = capitaliseAddress(address.address)
+  this.leadLocalFloodAuthority = risk.leadLocalFloodAuthority
+  this.date = Date.now()
+  this.year = new Date().getFullYear()
+  this.riversAndSeaTitle = RiskTitles[riverAndSeaRisk]
+  this.surfaceWaterTitle = RiskTitles[surfaceWaterRisk]
+
+  if (riverAndSeaRisk) {
+    const name = riverAndSeaRisk.toLowerCase()
+    this.riversAndSeaTextName = `partials/riskdescriptions/${name.replace(/ /g, '-')}.html`
+  }
+
+  if (surfaceWaterRisk) {
+    const name = surfaceWaterRisk.toLowerCase()
+    this.surfaceWaterTextName = `partials/riskdescriptions/${name.replace(/ /g, '-')}.html`
+  }
+
+  const riversAndSeaLevel = Levels.indexOf(riverAndSeaRisk)
+  const surfaceWaterLevel = Levels.indexOf(surfaceWaterRisk)
+  const surfaceWaterIsFirst = surfaceWaterLevel >= riversAndSeaLevel
+
+  processHighestRisk.call(this, surfaceWaterLevel, riversAndSeaLevel, riverAndSeaRisk)
+
+  if (surfaceWaterIsFirst) {
+    this.firstSource = 'surface-water.html'
+    this.secondSource = 'rivers-sea.html'
+  } else {
+    this.firstSource = 'rivers-sea.html'
+    this.secondSource = 'surface-water.html'
+  }
+  if (config.riskPageFlag) {
+    this.firstSource = 'partials/flagged/' + this.firstSource
+    this.secondSource = 'partials/flagged/' + this.secondSource
+    this.additionalInformation = 'partials/flagged/groundwaterAndReservoirs.html'
+  } else {
+    this.firstSource = 'partials/' + this.firstSource
+    this.secondSource = 'partials/' + this.secondSource
+    this.additionalInformation = 'partials/groundwaterAndReservoirs.html'
+  }
+  this.surfaceWaterIsFirst = surfaceWaterIsFirst
+  this.testInfo = JSON.stringify({
+    riverAndSeaRisk,
+    surfaceWaterRisk,
+    reservoirRisk,
+    isGroundwaterArea: risk.isGroundwaterArea
+  })
+}
+
+module.exports = riskViewModel
+
+function processHighestRisk (surfaceWaterLevel, riversAndSeaLevel, riverAndSeaRisk) {
+  this.highestRisk = 'partials/flagged/blank.html'
+  if ((surfaceWaterLevel < riversAndSeaLevel) && (riverAndSeaRisk !== 'Very Low')) { this.highestRisk = 'partials/flagged/rsl.html' }
+  if ((surfaceWaterLevel > riversAndSeaLevel) && (riverAndSeaRisk !== 'Very Low')) { this.highestRisk = 'partials/flagged/w.html' }
+  if ((surfaceWaterLevel === riversAndSeaLevel) && (riverAndSeaRisk !== 'Very Low')) { this.highestRisk = 'partials/flagged/rsl-sw.html' }
+}
+
+function processSuitability (risk) {
+  const riverAndSeaSuitability = risk.riverAndSeaRisk?.suitability
   if (riverAndSeaSuitability) {
     const name = riverAndSeaSuitability.toLowerCase()
     if (suitabilities.includes(name)) {
@@ -87,15 +138,36 @@ function RiskViewModel (risk, address, backLinkUri) {
       this.surfaceWaterSuitabilityName = `partials/suitability/${name.replace(/ /g, '-')}.html`
     }
   }
+}
 
-  // Groundwater area
-  this.isGroundwaterArea = risk.isGroundwaterArea
-  this.extraInfo = risk.extraInfo
+function processReservoirs (reservoirDryRisk, risk, reservoirWetRisk) {
+  const reservoirs = []
 
-  this.hasHoldingComments = false
-  this.hasLlfaComments = false
+  const add = function (item) {
+    reservoirs.push({
+      name: item.reservoirName,
+      owner: item.undertaker,
+      authority: item.leadLocalFloodAuthority,
+      location: item.location,
+      riskDesignation: item.riskDesignation,
+      comments: item.comments
+    })
+  }
 
-  // Extra info
+  if (reservoirDryRisk) {
+    risk.reservoirDryRisk.forEach(add)
+  }
+
+  if (reservoirWetRisk) {
+    risk.reservoirWetRisk
+      .filter(item => !reservoirs.find(r => r.location === item.location))
+      .forEach(item => add(item))
+  }
+
+  this.reservoirs = reservoirs
+}
+
+function processExtraInfo (risk) {
   if (Array.isArray(risk.extraInfo) && risk.extraInfo.length) {
     const maxComments = 3
     const llfaDescriptions = {
@@ -124,47 +196,4 @@ function RiskViewModel (risk, address, backLinkUri) {
     this.hasHoldingComments = !!this.holdingComments.length
     this.hasLlfaComments = !!this.llfaComments.length
   }
-
-  this.easting = address.x
-  this.northing = address.y
-  this.postcode = address.postcode
-  this.lines = address.address.split(', ')
-  this.address = address
-  this.fullAddress = capitaliseAddress(address.address)
-  this.leadLocalFloodAuthority = risk.leadLocalFloodAuthority
-  this.date = Date.now()
-  this.year = new Date().getFullYear()
-  this.riversAndSeaTitle = RiskTitles[riverAndSeaRisk]
-  this.surfaceWaterTitle = RiskTitles[surfaceWaterRisk]
-
-  if (riverAndSeaRisk) {
-    const name = riverAndSeaRisk.toLowerCase()
-    this.riversAndSeaTextName = `partials/riskdescriptions/${name.replace(/ /g, '-')}.html`
-  }
-
-  if (surfaceWaterRisk) {
-    const name = surfaceWaterRisk.toLowerCase()
-    this.surfaceWaterTextName = `partials/riskdescriptions/${name.replace(/ /g, '-')}.html`
-  }
-
-  const riversAndSeaLevel = Levels.indexOf(riverAndSeaRisk)
-  const surfaceWaterLevel = Levels.indexOf(surfaceWaterRisk)
-  const riversAndSeaIsFirst = riversAndSeaLevel >= surfaceWaterLevel
-
-  if (riversAndSeaIsFirst) {
-    this.firstSource = 'partials/rivers-sea.html'
-    this.secondSource = 'partials/surface-water.html'
-  } else {
-    this.firstSource = 'partials/surface-water.html'
-    this.secondSource = 'partials/rivers-sea.html'
-  }
-
-  this.testInfo = JSON.stringify({
-    riverAndSeaRisk,
-    surfaceWaterRisk,
-    reservoirRisk,
-    isGroundwaterArea: risk.isGroundwaterArea
-  })
 }
-
-module.exports = RiskViewModel

--- a/node/risk-app/server/plugins/router.js
+++ b/node/risk-app/server/plugins/router.js
@@ -27,6 +27,12 @@ if (config.simulateAddressService) {
   routes.push(require('../routes/os-get-capabilities'))
 }
 
+if (config.riskPageFlag) {
+  routes.push(require('../routes/surface-water'))
+  routes.push(require('../routes/rivers-and-sea'))
+  routes.push(require('../routes/ground-water'))
+}
+
 module.exports = {
   plugin: {
     name: 'router',

--- a/node/risk-app/server/routes/__tests__/ground-water.spec.js
+++ b/node/risk-app/server/routes/__tests__/ground-water.spec.js
@@ -1,0 +1,166 @@
+const STATUS_CODES = require('http2').constants
+const createServer = require('../../../server')
+const riskService = require('../../services/risk')
+const { getByCoordinates } = require('../../services/risk')
+const config = require('../../config')
+const { mockOptions, mockSearchOptions } = require('../../../test/mock')
+const defaultOptions = {
+  method: 'GET',
+  url: '/risk'
+}
+
+jest.mock('../../config')
+jest.mock('../../services/flood')
+jest.mock('../../services/address')
+jest.mock('../../services/risk')
+
+let server, cookie
+
+function checkCookie (response) {
+  if (response.headers['set-cookie']) {
+    cookie = response.headers['set-cookie'][0].split(';')[0]
+    defaultOptions.headers = { cookie }
+  }
+}
+
+describe('GET /ground-water', () => {
+  beforeAll(async () => {
+    config.setConfigOptions({
+      riskPageFlag: true,
+      friendlyCaptchaEnabled: false
+    })
+    server = await createServer()
+    await server.initialize()
+    const initial = mockOptions()
+
+    const homepageresponse = await server.inject(initial)
+    expect(homepageresponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    checkCookie(homepageresponse)
+  })
+
+  beforeEach(async () => {
+    const { getOptions, postOptions } = mockSearchOptions('NP18 3EZ', cookie)
+    let postResponse = await server.inject(postOptions)
+    expect(postResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
+    expect(postResponse.headers.location).toMatch(`/search?postcode=${encodeURIComponent('NP18 3EZ')}`)
+
+    const getResponse = await server.inject(getOptions)
+    checkCookie(getResponse)
+    expect(getResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    postOptions.url = `/search?postcode=${encodeURIComponent('NP18 3EZ')}`
+    postOptions.payload = 'address=0'
+
+    postResponse = await server.inject(postOptions)
+    checkCookie(postResponse)
+    expect(postResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
+    expect(postResponse.headers.location).toMatch('/risk')
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  afterEach(async () => {
+    riskService.__resetReturnValue()
+  })
+
+  it('redirects to postcode page if user does not have an address set in session', async () => {
+    // Get postcode page first to clear the previous address selection
+    const mockRequest = {
+      method: 'GET',
+      url: '/postcode',
+      headers: defaultOptions.headers
+    }
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+
+    mockRequest.url = '/ground-water'
+    const swResponse = await server.inject(mockRequest)
+    expect(swResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
+    expect(swResponse.headers.location).toBe('/postcode')
+  })
+
+  it('returns 200 OK and renders rivers and sea page if user has an address set in session', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/ground-water',
+      headers: defaultOptions.headers
+    }
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    expect(response.result).toContain('ground-water')
+  })
+
+  it('should show an error page if an error occurs', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/ground-water',
+      headers: defaultOptions.headers
+    }
+    getByCoordinates.mockImplementationOnce(() => {
+      throw new Error()
+    })
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_BAD_REQUEST)
+  })
+
+  it('should create an array of reservoirs if there is a reservoirs risk', async () => {
+    riskService.getByCoordinates.mockResolvedValue({
+      reservoirDryRisk: [{
+        reservoirName: 'Dry Risk Resevoir',
+        location: 'SJ917968',
+        riskDesignation: 'High-risk',
+        undertaker: 'United Utilities PLC',
+        leadLocalFloodAuthority: 'Tameside',
+        comments: 'If you have questions about local emergency plans for this reservoir you should contact the named Local Authority'
+      }]
+    })
+
+    const mockRequest = {
+      method: 'GET',
+      url: '/ground-water',
+      headers: defaultOptions.headers
+    }
+
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    expect(response.result).toContain('Dry Risk Resevoir')
+  })
+
+  it('should add any reservoirs that are not in the list when it is wet', async () => {
+    riskService.getByCoordinates.mockResolvedValue({
+      reservoirDryRisk: [{
+        reservoirName: 'Dry Risk Resevoir',
+        location: 'SJ917968',
+        riskDesignation: 'High-risk',
+        undertaker: 'United Utilities PLC',
+        leadLocalFloodAuthority: 'Tameside',
+        comments: 'If you have questions about local emergency plans for this reservoir you should contact the named Local Authority'
+      }],
+      reservoirWetRisk: [{
+        reservoirName: 'Wet Risk Reservoir',
+        location: 'Another location',
+        riskDesignation: 'High-risk',
+        undertaker: 'United Utilities PLC',
+        leadLocalFloodAuthority: 'Tameside',
+        comments: 'If you have questions about local emergency plans for this reservoir you should contact the named Local Authority'
+      }]
+    })
+
+    const mockRequest = {
+      method: 'GET',
+      url: '/ground-water',
+      headers: defaultOptions.headers
+    }
+
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    expect(response.result).toContain('Dry Risk Resevoir')
+    expect(response.result).toContain('Wet Risk Reservoir')
+  })
+})

--- a/node/risk-app/server/routes/__tests__/rivers-and-sea-disabled.spec.js
+++ b/node/risk-app/server/routes/__tests__/rivers-and-sea-disabled.spec.js
@@ -1,0 +1,29 @@
+const STATUS_CODES = require('http2').constants
+const createServer = require('../../../server')
+const config = require('../../config')
+
+jest.mock('../../config')
+
+describe('GET /rivers-and-sea with risk flag disabled', () => {
+  let server
+
+  beforeAll(async () => {
+    config.setConfigOptions({ riskPageFlag: false })
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  it('throws an error if the risk page flag is not set, disallowing access to page', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/rivers-and-sea'
+    }
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_NOT_FOUND)
+  })
+})

--- a/node/risk-app/server/routes/__tests__/rivers-and-sea-enabled.spec.js
+++ b/node/risk-app/server/routes/__tests__/rivers-and-sea-enabled.spec.js
@@ -1,0 +1,125 @@
+const STATUS_CODES = require('http2').constants
+const createServer = require('../../../server')
+const riskService = require('../../services/risk')
+const { getByCoordinates } = require('../../services/risk')
+const config = require('../../config')
+const { mockOptions, mockSearchOptions } = require('../../../test/mock')
+const defaultOptions = {
+  method: 'GET',
+  url: '/risk'
+}
+
+jest.mock('../../config')
+jest.mock('../../services/flood')
+jest.mock('../../services/address')
+jest.mock('../../services/risk')
+
+let server, cookie
+
+function checkCookie (response) {
+  if (response.headers['set-cookie']) {
+    cookie = response.headers['set-cookie'][0].split(';')[0]
+    defaultOptions.headers = { cookie }
+  }
+}
+
+describe('GET /rivers-and-sea - flag enabled', () => {
+  beforeAll(async () => {
+    config.setConfigOptions({
+      riskPageFlag: true,
+      friendlyCaptchaEnabled: false
+    })
+    server = await createServer()
+    await server.initialize()
+    const initial = mockOptions()
+
+    const homepageresponse = await server.inject(initial)
+    expect(homepageresponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    checkCookie(homepageresponse)
+  })
+
+  beforeEach(async () => {
+    const { getOptions, postOptions } = mockSearchOptions('NP18 3EZ', cookie)
+    let postResponse = await server.inject(postOptions)
+    expect(postResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
+    expect(postResponse.headers.location).toMatch(`/search?postcode=${encodeURIComponent('NP18 3EZ')}`)
+
+    const getResponse = await server.inject(getOptions)
+    checkCookie(getResponse)
+    expect(getResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    postOptions.url = `/search?postcode=${encodeURIComponent('NP18 3EZ')}`
+    postOptions.payload = 'address=0'
+
+    postResponse = await server.inject(postOptions)
+    checkCookie(postResponse)
+    expect(postResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
+    expect(postResponse.headers.location).toMatch('/risk')
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  afterEach(async () => {
+    riskService.__resetReturnValue()
+  })
+
+  it('redirects to postcode page if user does not have an address set in session', async () => {
+    // Get postcode page first to clear the previous address selection
+    const mockRequest = {
+      method: 'GET',
+      url: '/postcode',
+      headers: defaultOptions.headers
+    }
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+
+    mockRequest.url = '/rivers-and-sea'
+    const swResponse = await server.inject(mockRequest)
+    expect(swResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
+    expect(swResponse.headers.location).toBe('/postcode')
+  })
+
+  it('returns 200 OK and renders rivers and sea page if user has an address set in session', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/rivers-and-sea',
+      headers: defaultOptions.headers
+    }
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    expect(response.result).toContain('rivers-and-sea')
+  })
+
+  it('should show an error page if an error occurs', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/rivers-and-sea',
+      headers: defaultOptions.headers
+    }
+    getByCoordinates.mockImplementationOnce(() => {
+      throw new Error()
+    })
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_BAD_REQUEST)
+  })
+
+  it('should return "Very low" risk probability when riverAndSeaRisk is not present', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/rivers-and-sea',
+      headers: defaultOptions.headers
+    }
+    riskService.__updateReturnValue({
+      riverAndSeaRisk: ''
+    })
+
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    expect(response.result).toContain('govuk-tag--Very-Low')
+  })
+})

--- a/node/risk-app/server/routes/__tests__/search.js
+++ b/node/risk-app/server/routes/__tests__/search.js
@@ -132,17 +132,6 @@ describe('search page route', () => {
     expect(getResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
   })
 
-  test('/search - Invalid query', async () => {
-    const options = {
-      method: 'GET',
-      url: '/search?invalid=foo',
-      headers: { cookie }
-    }
-    floodService.__updateReturnValue({})
-    const getResponse = await server.inject(options)
-    expect(getResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_BAD_REQUEST)
-  })
-
   test('/search - Address service error', async () => {
     const { getOptions } = mockSearchOptions(DEFAULT_POSTCODE, cookie)
     floodService.__updateReturnValue({})
@@ -216,18 +205,5 @@ describe('search page route', () => {
     floodService.__updateReturnValue({})
     const getResponse = await server.inject(options)
     expect(getResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
-  })
-
-  test('400 for missing expected query parameter', async () => {
-    const options = {
-      method: 'GET',
-      url: '/search?test=test',
-      headers: {
-        cookie
-      }
-    }
-    floodService.__updateReturnValue({})
-    const getResponse = await server.inject(options)
-    expect(getResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_BAD_REQUEST)
   })
 })

--- a/node/risk-app/server/routes/__tests__/surface-water-disabled.spec.js
+++ b/node/risk-app/server/routes/__tests__/surface-water-disabled.spec.js
@@ -1,0 +1,29 @@
+const STATUS_CODES = require('http2').constants
+const createServer = require('../../../server')
+const config = require('../../config')
+
+jest.mock('../../config')
+
+describe('GET /surface-water - disabled', () => {
+  let server
+
+  beforeAll(async () => {
+    config.setConfigOptions({ riskPageFlag: false })
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  it('throws an error if the risk page flag is not set, disallowing access to page', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/rivers-and-sea'
+    }
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_NOT_FOUND)
+  })
+})

--- a/node/risk-app/server/routes/__tests__/surface-water-enabled.spec.js
+++ b/node/risk-app/server/routes/__tests__/surface-water-enabled.spec.js
@@ -1,0 +1,189 @@
+const STATUS_CODES = require('http2').constants
+const createServer = require('../../../server')
+const riskService = require('../../services/risk')
+const { getByCoordinates } = require('../../services/risk')
+const config = require('../../config')
+const { mockOptions, mockSearchOptions } = require('../../../test/mock')
+const defaultOptions = {
+  method: 'GET',
+  url: '/risk'
+}
+
+jest.mock('../../config')
+jest.mock('../../services/flood')
+jest.mock('../../services/address')
+jest.mock('../../services/risk')
+
+let server, cookie
+
+function checkCookie (response) {
+  if (response.headers['set-cookie']) {
+    cookie = response.headers['set-cookie'][0].split(';')[0]
+    defaultOptions.headers = { cookie }
+  }
+}
+
+describe('GET /surface-water - enabled', () => {
+  beforeAll(async () => {
+    config.setConfigOptions({
+      riskPageFlag: true,
+      friendlyCaptchaEnabled: false
+    })
+    server = await createServer()
+    await server.initialize()
+    const initial = mockOptions()
+
+    const homepageresponse = await server.inject(initial)
+    expect(homepageresponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    checkCookie(homepageresponse)
+  })
+
+  beforeEach(async () => {
+    const { getOptions, postOptions } = mockSearchOptions('NP18 3EZ', cookie)
+    let postResponse = await server.inject(postOptions)
+    expect(postResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
+    expect(postResponse.headers.location).toMatch(`/search?postcode=${encodeURIComponent('NP18 3EZ')}`)
+
+    const getResponse = await server.inject(getOptions)
+    checkCookie(getResponse)
+    expect(getResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    postOptions.url = `/search?postcode=${encodeURIComponent('NP18 3EZ')}`
+    postOptions.payload = 'address=0'
+
+    postResponse = await server.inject(postOptions)
+    checkCookie(postResponse)
+    expect(postResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
+    expect(postResponse.headers.location).toMatch('/risk')
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  afterEach(async () => {
+    riskService.__resetReturnValue()
+  })
+
+  it('redirects to postcode page if user does not have an address set in session', async () => {
+    // Get postcode page first to clear the previous address selection
+    const mockRequest = {
+      method: 'GET',
+      url: '/postcode',
+      headers: defaultOptions.headers
+    }
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+
+    mockRequest.url = '/surface-water'
+    const swResponse = await server.inject(mockRequest)
+    expect(swResponse.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_FOUND)
+    expect(swResponse.headers.location).toBe('/postcode')
+  })
+
+  it('returns 200 OK and renders surface water page if user has an address set in session', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/surface-water',
+      headers: defaultOptions.headers
+    }
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    expect(response.result).toContain('surface-water')
+  })
+
+  it('returns 200 OK and renders surface water page with high risk', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/surface-water',
+      headers: defaultOptions.headers
+    }
+    riskService.__updateReturnValue({
+      surfaceWaterRisk: 'High'
+    })
+
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    expect(response.result).toContain('govuk-tag--High')
+  })
+
+  it('returns 200 OK and renders surface water page with medium risk', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/surface-water',
+      headers: defaultOptions.headers
+    }
+    riskService.__updateReturnValue({
+      surfaceWaterRisk: 'Medium'
+    })
+
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    expect(response.result).toContain('govuk-tag--Medium')
+  })
+
+  it('returns 200 OK and renders surface water page with low risk', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/surface-water',
+      headers: defaultOptions.headers
+    }
+    riskService.__updateReturnValue({
+      surfaceWaterRisk: 'Low'
+    })
+
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    expect(response.result).toContain('govuk-tag--Low')
+  })
+
+  it('returns 200 OK and renders surface water page with very low risk', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/surface-water',
+      headers: defaultOptions.headers
+    }
+    riskService.__updateReturnValue({
+      surfaceWaterRisk: 'Very Low'
+    })
+
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    expect(response.result).toContain('govuk-tag--Very-Low')
+  })
+
+  it('returns 200 OK and renders surface water page with lead local flood authority', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/surface-water',
+      headers: defaultOptions.headers
+    }
+    riskService.__updateReturnValue({
+      leadLocalFloodAuthority: 'North Yorkshire'
+    })
+
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_OK)
+    expect(response.result).toContain('Your lead local flood authority is <strong>North Yorkshire')
+  })
+
+  it('should show an error page if an error occurs', async () => {
+    const mockRequest = {
+      method: 'GET',
+      url: '/surface-water',
+      headers: defaultOptions.headers
+    }
+    getByCoordinates.mockImplementationOnce(() => {
+      throw new Error()
+    })
+    const response = await server.inject(mockRequest)
+
+    expect(response.statusCode).toEqual(STATUS_CODES.HTTP_STATUS_BAD_REQUEST)
+  })
+})

--- a/node/risk-app/server/routes/ground-water.js
+++ b/node/risk-app/server/routes/ground-water.js
@@ -1,0 +1,32 @@
+const riskService = require('../services/risk')
+const boom = require('@hapi/boom')
+const errors = require('../models/errors.json')
+const GroundWaterViewModel = require('../models/risk-view')
+
+module.exports = {
+  method: 'GET',
+  path: '/ground-water',
+  handler: async (request, h) => {
+    const address = request.yar.get('address')
+
+    if (!address) {
+      return h.redirect('/postcode')
+    }
+
+    const { x, y } = address
+    const radius = 15
+    const backLinkUri = '/risk'
+
+    try {
+      const risk = await riskService.getByCoordinates(x, y, radius)
+
+      const model = new GroundWaterViewModel(risk, address, backLinkUri)
+      return h.view('ground-water', model)
+    } catch (err) {
+      return boom.badRequest(errors.riskProfile.message, err)
+    }
+  },
+  options: {
+    description: 'Understand rivers and the sea page'
+  }
+}

--- a/node/risk-app/server/routes/postcode.js
+++ b/node/risk-app/server/routes/postcode.js
@@ -10,6 +10,7 @@ module.exports = [
     path: '/postcode',
     handler: (request, h) => {
       request.yar.set('address', null)
+      request.yar.set('postcode', null)
       const error = request.query.error
 
       if (error) {

--- a/node/risk-app/server/routes/risk.js
+++ b/node/risk-app/server/routes/risk.js
@@ -2,6 +2,7 @@ const boom = require('@hapi/boom')
 const riskService = require('../services/risk')
 const RiskViewModel = require('../models/risk-view')
 const errors = require('../models/errors.json')
+const config = require('../config')
 const { defineBackLink } = require('../services/defineBackLink.js')
 
 module.exports = {
@@ -41,10 +42,10 @@ module.exports = {
 
         if (!risk.inEngland) {
           return h.redirect('/england-only')
-        } else {
-          const backLinkUri = defineBackLink(path, address.postcode)
-          return h.view('risk', new RiskViewModel(risk, address, backLinkUri))
         }
+        const backLinkUri = defineBackLink(path, address.postcode)
+        const htmlFile = config.riskPageFlag ? 'risk-flagged' : 'risk'
+        return h.view(htmlFile, new RiskViewModel(risk, address, backLinkUri))
       } catch (err) {
         return boom.badRequest(errors.riskProfile.message, err)
       }

--- a/node/risk-app/server/routes/rivers-and-sea.js
+++ b/node/risk-app/server/routes/rivers-and-sea.js
@@ -1,0 +1,31 @@
+const riskService = require('../services/risk')
+const boom = require('@hapi/boom')
+const errors = require('../models/errors.json')
+const RiversAndSeaViewModel = require('../models/risk-view')
+
+module.exports = {
+  method: 'GET',
+  path: '/rivers-and-sea',
+  handler: async (request, h) => {
+    const address = request.yar.get('address')
+
+    if (!address) {
+      return h.redirect('/postcode')
+    }
+
+    const { x, y } = address
+    const radius = 15
+    const backLinkUri = '/risk'
+
+    try {
+      const risk = await riskService.getByCoordinates(x, y, radius)
+      const model = new RiversAndSeaViewModel(risk, address, backLinkUri)
+      return h.view('rivers-and-sea', model)
+    } catch (err) {
+      return boom.badRequest(errors.riskProfile.message, err)
+    }
+  },
+  options: {
+    description: 'Understand rivers and the sea page'
+  }
+}

--- a/node/risk-app/server/routes/search.js
+++ b/node/risk-app/server/routes/search.js
@@ -28,7 +28,10 @@ module.exports = [
     path: '/search',
     handler: async (request, h) => {
       let addresses
-      const { postcode } = request.query
+      let { postcode } = request.query
+      if (!postcode) {
+        postcode = request.yar.get('postcode')
+      }
       const path = request.path
 
       // Our Address service doesn't support NI addresses
@@ -53,7 +56,8 @@ module.exports = [
 
         // Set addresses to session
         request.yar.set({
-          addresses
+          addresses,
+          postcode
         })
 
         if (!addresses || !addresses.length) {
@@ -78,8 +82,8 @@ module.exports = [
       },
       validate: {
         query: joi.object().keys({
-          postcode: joi.string().trim().regex(postcodeRegex).required()
-        }).required()
+          postcode: joi.string().trim().regex(postcodeRegex).default('')
+        })
       }
     }
   },
@@ -87,7 +91,10 @@ module.exports = [
     method: 'POST',
     path: '/search',
     handler: async (request, h) => {
-      const { postcode } = request.query
+      let { postcode } = request.query
+      if (!postcode) {
+        postcode = request.yar.get('postcode')
+      }
       const { address } = request.payload
       const addresses = request.yar.get('addresses')
 
@@ -121,7 +128,7 @@ module.exports = [
       description: 'Post to the search page',
       validate: {
         query: joi.object().keys({
-          postcode: joi.string().trim().regex(postcodeRegex).required()
+          postcode: joi.string().trim().regex(postcodeRegex).default('')
         }),
         payload: joi.object().keys({
           address: joi.number().required()

--- a/node/risk-app/server/routes/surface-water.js
+++ b/node/risk-app/server/routes/surface-water.js
@@ -1,0 +1,39 @@
+const boom = require('@hapi/boom')
+const riskService = require('../services/risk')
+const SurfaceWaterViewModel = require('../models/risk-view')
+const errors = require('../models/errors.json')
+
+module.exports = {
+  method: 'GET',
+  path: '/surface-water',
+  handler: async (request, h) => {
+    try {
+      const address = request.yar.get('address')
+
+      if (!address) {
+        return h.redirect('/postcode')
+      }
+
+      const { x, y } = address
+      const radius = 15
+      const backLinkUri = '/risk'
+
+      try {
+        const risk = await riskService.getByCoordinates(x, y, radius)
+
+        if (!risk.inEngland) {
+          return h.redirect('/england-only')
+        } else {
+          return h.view('surface-water', new SurfaceWaterViewModel(risk, address, backLinkUri))
+        }
+      } catch (err) {
+        return boom.badRequest(errors.riskProfile.message, err)
+      }
+    } catch (err) {
+      return boom.badRequest(errors.addressById.message, err)
+    }
+  },
+  options: {
+    description: 'Surface water risk description'
+  }
+}

--- a/node/risk-app/server/views/ground-water.html
+++ b/node/risk-app/server/views/ground-water.html
@@ -1,0 +1,156 @@
+{% extends 'layout.html' %}
+
+{% set pageTitle = "Groundwater and reservoirs: understand your flood risk" %}
+{% set currentpage = "groundwater" %}
+
+{% block head %}
+{{ super() }}
+<link href="{{ assetPath }}/stylesheets/risk-data.css" rel="stylesheet" />
+<link href="{{ assetPath }}/stylesheets/rivers-and-sea.css" rel="stylesheet" />
+{% endblock %}
+
+{% block beforeContent %}
+<div class="top-page-links">
+  <a href="{{ backLink }}" class="govuk-back-link" data-id="risk-address">Back to summary</a>
+</div>
+{% endblock %}
+
+{% block content %}          
+  <div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-l govuk-!-padding-top-0 h1-gap">
+       Groundwater and reservoirs: understand your flood risk
+        </h1>
+      </div>
+  </div>
+  
+  <nav aria-label="Pages with more detail" class="gem-c-contents-list" role="navigation">
+    <ol class="gem-c-contents-list__list">
+      {% if surfaceWaterIsFirst %}
+      {% include 'partials/flagged/nav-sw.njk' %}
+      {% endif %}
+      {% include 'partials/flagged/nav-rs.njk' %}
+      {% if not surfaceWaterIsFirst %}
+      {% include 'partials/flagged/nav-sw.njk' %}
+      {% endif %}
+      {% include 'partials/flagged/nav-gw.njk' %}
+        </ol>
+  </nav>
+  
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+  <div class="govuk-summary-card" id="groundwater">
+    <div class="govuk-summary-card__title-wrapper vlow card-padding-left">
+      <h2 class="govuk-summary-card__title">Groundwater<span class="chance-content gw-context">{% if isGroundwaterArea %}
+        Flooding is possible when groundwater levels are high.
+        {% else %}
+        Flooding from groundwater is unlikely in this area.
+        {% endif %}</span></h2>
+      <ul class="govuk-summary-card__actions">
+      </ul>
+    </div>
+    <div class="govuk-summary-card__content">
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            What groundwater is
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p class="govuk-body">Groundwater is the water that is usually held in rocks and soil underground.</p> <p class="govuk-body">Groundwater flooding happens when this water rises and flows above the surface.</p>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            How we check an area's risk
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p class="govuk-body govuk-!-margin-bottom-2">We use flood alert data to check the risk of flooding from groundwater.</p>
+          </dd>
+        </div>     
+      </dl>
+    </div>
+  </div>
+  
+  <div class="govuk-summary-card" id="reservoirs">
+    <div class="govuk-summary-card__title-wrapper vlow card-padding-left">
+      <h2 class="govuk-summary-card__title">Reservoirs<span class="chance-content gw-context">{% if reservoirRisk %}
+        There is a risk of flooding from reservoirs in this area.
+        {% else %}
+        Flooding from reservoirs is unlikely in this area.
+        {% endif %}</span></h2>
+      <ul class="govuk-summary-card__actions">
+      </ul>
+    </div>
+    <div class="govuk-summary-card__content">
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            What a reservoir is
+          </dt>
+          <dd class="govuk-summary-list__value">
+            A reservoir is a large natural or artificial lake that is designed to collect and store water.
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            How we check an area's risk
+          </dt>
+          <dd class="govuk-summary-list__value">
+            We use predicted scenarios to understand the risk of flooding from reservoirs.
+            <br><br>
+            Flooding from reservoirs is extremely unlikely. An area is considered at risk if people’s lives could be threatened in the event of a dam or reservoir failure.
+            {% if (reservoirRisk) %}
+            <br><br>
+            <a class="govuk-link" href="/map?easting={{easting}}&northing={{northing}}&map=Reservoirs">View a map of the risk of flooding from reservoirs</a>
+            <br><br>
+            <details class="govuk-details reservoirs" data-module="govuk-details">
+              <summary class="govuk-details__summary reservoirs" data-journey-click="ltfri:risk:reservoir-details">
+                <span class="govuk-details__summary-text reservoirs">
+                  Reservoirs that could affect this area
+                </span>
+              </summary>
+              {% for reservoir in reservoirs %}
+              <ul class="govuk-list reservoirs" id="reservoirs-risk-reservoir-list">
+                <li><strong>{{reservoir.name}}</strong> (grid reference {{reservoir.location}})</li>
+                <li>Owner: {{reservoir.owner}}</li>
+                <li>Lead Local Flood Authority: {{reservoir.authority}}</li>
+                <li>Comments: {{reservoir.comments}}</li>
+              </ul>
+              {% endfor %}
+            </details>
+            {% endif %}
+          </dd>
+        </div>    
+      </dl>
+    </div>
+  </div>
+  </div>
+  </div>
+      
+      </div>
+  
+      <!-- end of details -->
+      <nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+        {% if surfaceWaterIsFirst %}
+        <div class="govuk-pagination__prev">
+          <a class="govuk-link govuk-pagination__link" href="/rivers-and-sea" rel="prev" previewlistener="true">
+            <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+              <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+            </svg>
+            <span class="govuk-pagination__link-title">Previous</span><span class="govuk-visually-hidden">:</span>
+            <span class="govuk-pagination__link-label">Rivers and the sea</span></a>
+        </div>
+        {% else %}
+        <div class="govuk-pagination__prev">
+          <a class="govuk-link govuk-pagination__link" href="/surface-water" rel="prev" previewlistener="true">
+            <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+              <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+            </svg>
+            <span class="govuk-pagination__link-title">Previous</span><span class="govuk-visually-hidden">:</span>
+            <span class="govuk-pagination__link-label">Surface water</span></a>
+        </div>
+        {% endif %}
+      </nav>
+      <!-- end of nav -->
+{% endblock %}

--- a/node/risk-app/server/views/partials/flagged/groundwaterAndReservoirs.html
+++ b/node/risk-app/server/views/partials/flagged/groundwaterAndReservoirs.html
@@ -1,0 +1,40 @@
+<div class="govuk-summary-card">
+  <div class="govuk-summary-card__title-wrapper vlow card-padding-left">
+    <h2 class="govuk-summary-card__title card-title__font-size">Other flood risks</h2>
+    <ul class="govuk-summary-card__actions">
+      <li class="govuk-summary-card__action">
+        <a class="govuk-link" href="/ground-water">
+          More about groundwater and reservoirs
+      </a>
+      </li>
+    </ul>
+  </div>
+  <div class="govuk-summary-card__content">
+    <dl class="govuk-summary-list">
+      
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+         Groundwater
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {% if isGroundwaterArea %}
+          Flooding is possible when groundwater levels are high.
+          {% else %}
+          Flooding from groundwater is unlikely in this area.
+          {% endif %}
+          <br><br>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+         Reservoirs
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {% if reservoirRisk %}
+          There is a risk of flooding from reservoirs in this area.
+          {% else %}
+          Flooding from reservoirs is unlikely in this area.
+          {% endif %}
+        </dd>
+      </div>
+  </div>

--- a/node/risk-app/server/views/partials/flagged/nav-gw.njk
+++ b/node/risk-app/server/views/partials/flagged/nav-gw.njk
@@ -1,0 +1,10 @@
+{% if currentpage === 'groundwater' %}
+<li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed gem-c-contents-list__list-item--active" aria-current="true">
+  <strong>Groundwater and reservoirs</strong>
+ </li>
+{% else %}
+<li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+  <a class="gem-c-contents-list__link govuk-link" href="/ground-water" 
+  aria-label="Ground water and reservoirs understand your flood risk page." previewlistener="true">Groundwater and reservoirs</a>
+</li>
+{% endif %}

--- a/node/risk-app/server/views/partials/flagged/nav-rs.njk
+++ b/node/risk-app/server/views/partials/flagged/nav-rs.njk
@@ -1,0 +1,12 @@
+{% if currentpage === 'rivers-and-sea' %}
+<li
+class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed gem-c-contents-list__list-item--active"
+aria-current="true">
+<strong>Rivers and the sea</strong>
+</li>
+{% else %}
+<li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+  <a class="gem-c-contents-list__link govuk-link" href="/rivers-and-sea" previewlistener="true" 
+  aria-label="Rivers and the sea understand your flood risk page.">Rivers and the sea</a>
+</li>
+{% endif %}

--- a/node/risk-app/server/views/partials/flagged/nav-sw.njk
+++ b/node/risk-app/server/views/partials/flagged/nav-sw.njk
@@ -1,0 +1,12 @@
+{% if currentpage === 'surface-water' %}
+<li
+class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed gem-c-contents-list__list-item--active"
+aria-current="true">
+<strong>Surface
+  water</strong>
+</li>
+{% else %}
+<li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+  <a class="gem-c-contents-list__link govuk-link" href="/surface-water" previewlistener="true">Surface water</a>
+</li>
+{% endif %}

--- a/node/risk-app/server/views/partials/flagged/rivers-sea.html
+++ b/node/risk-app/server/views/partials/flagged/rivers-sea.html
@@ -1,0 +1,88 @@
+<div class="govuk-summary-card" id="rivers-sea">
+  <div class="govuk-summary-card__title-wrapper vlow card-padding-left">
+    <h2 class="govuk-summary-card__title card-title__font-size">Rivers and the sea</h2>
+    <ul class="govuk-summary-card__actions">
+      <li class="govuk-summary-card__action">
+        <a class="govuk-link card-link__font-size" href="/rivers-and-sea">
+          More about your rivers and sea flood risk
+      </a>
+      </li>
+    </ul>
+  </div>
+  <div class="govuk-summary-card__content">
+    <dl class="govuk-summary-list">
+      
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key" style="width: 100%;">
+          Yearly chance of flooding
+         <div class="risk-label-group govuk-!-margin-bottom-3">
+          {% if riverAndSeaRisk === "Very Low" %}
+          <strong class="govuk-tag govuk-tag--Very-Low label-mod label-border">
+            Very low<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
+          </strong>
+          {% else %}
+          <strong class="govuk-tag govuk-tag--grey label-mod" aria-hidden="true">
+            Very low
+          </strong>
+          {% endif %}
+
+          {% if riverAndSeaRisk === "Low" %}
+          <strong class="govuk-tag govuk-tag--Low label-mod label-border">
+            Low<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
+          </strong>
+          {% else %}
+          <strong class="govuk-tag govuk-tag--grey label-mod" aria-hidden="true">
+            Low
+          </strong>
+          {% endif %}
+
+          {% if riverAndSeaRisk === "Medium" %}
+          <strong class="govuk-tag govuk-tag--Medium label-mod label-border">
+            Medium<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
+          </strong>
+          {% else %}
+          <strong class="govuk-tag govuk-tag--grey label-mod" aria-hidden="true">
+            Medium
+          </strong>
+          {% endif %}
+
+          {% if riverAndSeaRisk === "High" %}
+          <strong class="govuk-tag govuk-tag--High label-mod label-border">
+            High<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
+          </strong>
+          {% else %}
+          <strong class="govuk-tag govuk-tag--grey label-mod" aria-hidden="true">
+            High
+          </strong>
+          {% endif %}
+  </dt>
+     
+       
+      </div>
+      
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          What makes rivers and sea flooding more likely
+          <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-2">Low-lying areas that are close to rivers or the sea are more likely to flood when water levels rise.
+          </p>
+          <p class="govuk-body">This information takes into account any flood defences.
+          </p>
+          
+          <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-3" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                Why flood defences cannot completely prevent flooding
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              <p class="govuk-body">Flood defences can help reduce the chance of flooding but cannot completely prevent it because:</p>
+              <ul class="govuk-list--bullet">
+                <li>they can fail</li>
+                <li>water could spill over the top if it is deep enough</li>
+              </ul>
+            </div>
+          </details>
+          </dt>
+       </div>
+      </div> 
+</div>

--- a/node/risk-app/server/views/partials/flagged/rsl-sw.html
+++ b/node/risk-app/server/views/partials/flagged/rsl-sw.html
@@ -1,0 +1,2 @@
+<p class="govuk-body">The highest risks of flooding at this location are from
+  <strong>surface water</strong> and <strong>rivers and the sea</strong>.</p>

--- a/node/risk-app/server/views/partials/flagged/rsl.html
+++ b/node/risk-app/server/views/partials/flagged/rsl.html
@@ -1,0 +1,2 @@
+<p class="govuk-body">The highest risk of flooding at this location
+  is from <strong>rivers and the sea</strong>.</p>

--- a/node/risk-app/server/views/partials/flagged/surface-water.html
+++ b/node/risk-app/server/views/partials/flagged/surface-water.html
@@ -1,0 +1,86 @@
+<div class="govuk-summary-card govuk-!-margin-top-3" id="surface-water">
+  <div class="govuk-summary-card__title-wrapper vlow card-padding-left">
+    <h2 class="govuk-summary-card__title card-title__font-size">Surface water</h2>
+    <ul class="govuk-summary-card__actions">
+      <li class="govuk-summary-card__action">
+        <a class="govuk-link" href="/surface-water">
+          More about your surface water flood risk
+      </a>
+      </li>
+    </ul>
+  </div>
+  <div class="govuk-summary-card__content">
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key" style="width: 100%;">
+          Yearly chance of flooding
+              <div class="risk-label-group govuk-!-margin-bottom-3">
+                {% if surfaceWaterRisk === "Very Low" %}
+                <strong class="govuk-tag govuk-tag--Very-Low label-mod label-border">
+                  Very low<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
+                </strong>
+                {% else %}
+                <strong class="govuk-tag govuk-tag--grey label-mod" aria-hidden="true">
+                  Very low
+                </strong>
+                {% endif %}
+
+                {% if surfaceWaterRisk === "Low" %}
+                <strong class="govuk-tag govuk-tag--Low label-mod label-border">
+                  Low<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
+                </strong>
+                {% else %}
+                <strong class="govuk-tag govuk-tag--grey label-mod" aria-hidden="true">
+                  Low
+                </strong>
+                {% endif %}
+
+                {% if surfaceWaterRisk === "Medium" %}
+                <strong class="govuk-tag govuk-tag--Medium label-mod label-border">
+                  Medium<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
+                </strong>
+                {% else %}
+                <strong class="govuk-tag govuk-tag--grey label-mod" aria-hidden="true">
+                  Medium
+                </strong>
+                {% endif %}
+
+                {% if surfaceWaterRisk === "High" %}
+                <strong class="govuk-tag govuk-tag--High label-mod label-border">
+                  High<span class="govuk-visually-hidden"> within a scale of very low, low, medium and high.</span>
+                </strong>
+                {% else %}
+                <strong class="govuk-tag govuk-tag--grey label-mod" aria-hidden="true">
+                  High
+                </strong>
+                {% endif %}
+              </div>
+          </dt>
+      </div>
+    
+       <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          What surface water is
+          <p class="govuk-body govuk-!-margin-top-2">Surface water flooding is sometimes known as flash flooding. It happens when rainwater cannot drain away through normal drainage systems.
+          </p>
+          <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                Why surface water flooding is a problem
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              <p class="govuk-body">Surface water flooding is a problem because:</p>
+              <ul class="govuk-list--bullet">
+                <li>it often happens in places you don't expect, like up hills</li>
+                <li>it's hard to predict, as heavy rain sometimes only affects a small part of an area</li>
+                <li>where there's lots of tarmac and concrete the water has nowhere to go</li>
+              </ul>
+            </div>
+          </details>
+          </dt>
+       </div>
+      
+      
+      </div>
+</div>

--- a/node/risk-app/server/views/partials/flagged/sw.html
+++ b/node/risk-app/server/views/partials/flagged/sw.html
@@ -1,0 +1,2 @@
+<p class="govuk-body">The highest risk of flooding at this location
+  is from <strong>surface water</strong>.</p>

--- a/node/risk-app/server/views/partials/floodRatings.html
+++ b/node/risk-app/server/views/partials/floodRatings.html
@@ -1,0 +1,17 @@
+
+<details class="govuk-details govuk-!-margin-bottom-6 govuk-!-margin-top-2" data-module="govuk-details">
+  <summary class="govuk-details__summary" aria-label="Open dropdown for further information on the flood ratings.">
+    <span class="govuk-details__summary-text">
+      What the flood risk ratings mean
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <p class="govuk-body">'High' means more than 3.3% chance of a flood each year.</p>
+
+    <p class="govuk-body">'Medium' means between 1% and 3.3% chance of a flood each year.</p>
+
+    <p class="govuk-body">'Low' means between 0.1% and 1% chance of a flood each year.</p>
+
+    <p class="govuk-body">'Very low' means less than 0.1% chance of a flood each year.</p>
+  </div>
+</details>

--- a/node/risk-app/server/views/risk-flagged.html
+++ b/node/risk-app/server/views/risk-flagged.html
@@ -1,0 +1,131 @@
+{% extends 'layout.html' %}
+
+{% set pageTitle = "Your long term flood risk assessment" %}
+
+{% block beforeContent %}
+<div class="top-page-links">
+  <a href="/search" class="govuk-back-link" data-id="risk-address">Back to select an address</a>
+</div>
+{% endblock %}
+
+{% block head %}
+{{ super() }}
+<link href="{{ assetPath }}/stylesheets/risk-page.css" rel="stylesheet" />
+<link href="{{ assetPath }}/stylesheets/rivers-and-sea.css" rel="stylesheet" />
+{% endblock %}
+
+{% block content %}
+<div id="risk-page" data-test-info="{{ testInfo }}">
+  <!-- Page summary -->
+  <div class="page-summary ">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l govuk-!-padding-top-0">
+          {{ fullAddress }}
+        </h1>
+        {% include highestRisk %}
+        <p class="govuk-body">This information tells you the flood risk of an area, not a specific property.</p>
+        <p class="govuk-body">We have <a href="https://www.gov.uk/guidance/updates-to-national-flood-and-coastal-erosion-risk-information" class="govuk-link" data-journey-click="ltfri:risk:datapause">
+          paused updates to information about flood risk</a>
+        from rivers and the sea and surface water while we get ready for new data.</p>
+
+        <details class="govuk-details govuk-!-margin-bottom-3" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              How we assess an area's flood risk
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <p class="govuk-body">We use computer models to estimate flood risk, based on the best data we have available.</p>
+            <p class="govuk-body">The models do not include every local feature like kerbs, fences and walls. That means we can only tell you the flood risk of the area around a building, not the building itself.</p>
+            <p class="govuk-body">Neighbouring houses in a street may have different levels of flood risk. This could be because one is on higher land or is nearer water, for example.</p>
+            <p class="govuk-body">An area can still be at risk of flooding even if it has not flooded before.</p>
+            <p class="govuk-body">Any future flooding might not cover the same area as past flooding in the same location.</p>
+            <p class="govuk-body">Flooding is hard to predict, especially further into the future. Flood risks could be bigger or smaller than what we show, and could change over time.</p>
+           </div>
+        </details>
+
+        <!-- Holding Comments -->
+        {% if hasHoldingComments %}
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            <span class="govuk-warning-text__assistive">Warning</span>
+            {% for comment in holdingComments %}
+            <div class="{{ 'govuk-!-margin-bottom-4' if not loop.last }}">{{ comment }}</div>
+            {% endfor %}
+          </strong>
+        </div>
+        {% endif %}
+      </div>
+
+    <!-- Start of cards -->
+<div class="govuk-grid-column-two-thirds summary-grid-width">
+
+    {% include firstSource %}
+    {% include secondSource %}
+
+    <!-- Groundwater & Reservoir -->
+
+    {% include additionalInformation %}
+
+  </div>
+  <!-- end of two-thirds -->
+</div>
+
+  <!-- Print summary -->
+  <div class="print-summary">
+    <table class="govuk-table">
+      <caption class="govuk-table__caption">{{ address.address }}</caption>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Rivers and sea risk</th>
+          <td class="govuk-table__cell"><b>{{ riversAndSeaTitle }}</b><br>
+            {% if riversAndSeaTextName %}
+            {% include riversAndSeaTextName %}
+            {% endif %}</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Surface water risk</th>
+          <td class="govuk-table__cell">
+            <p>
+              <b>{{ surfaceWaterTitle }}</b><br>
+              {% if surfaceWaterTextName %}
+              {% include surfaceWaterTextName %}
+              {% endif %}
+            </p>
+            <p class="govuk-body">
+              Lead local flood authorities (LLFA) manage the risk from surface water flooding and may hold more
+              detailed information.
+              {% if leadLocalFloodAuthority %}Your LLFA is <b>{{leadLocalFloodAuthority}}</b>.{% endif %}
+            </p>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Reservoir risk</th>
+          <td class="govuk-table__cell">
+            {% if reservoirRisk %}
+            There is a risk of flooding from reservoirs in this area, reservoirs that can affect this area are:
+            <ul class="govuk-list govuk-list--bullet">
+              {% for reservoir in reservoirs %}
+              <li>{{reservoir.name}}</li>
+              {% endfor %}
+            </ul>
+            {% else %}
+            Flooding from reservoirs is unlikely in this area
+            {% endif %}
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Groundwater risk</th>
+          <td class="govuk-table__cell">
+            {{ "Flooding is possible in the local area when groundwater levels are high" if isGroundwaterArea else
+            "Flooding from groundwater is unlikely in this area" }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</div>
+{% endblock %}

--- a/node/risk-app/server/views/rivers-and-sea.html
+++ b/node/risk-app/server/views/rivers-and-sea.html
@@ -1,0 +1,122 @@
+{% extends 'layout.html' %}
+
+{% set pageTitle = "Rivers and the sea: understand your flood risk" %}
+{% set currentpage = "rivers-and-sea" %}
+
+{% block head %}
+{{ super() }}
+<link href="{{ assetPath }}/stylesheets/risk-data.css" rel="stylesheet" />
+<link href="{{ assetPath }}/stylesheets/rivers-and-sea.css" rel="stylesheet" />
+
+{% endblock %}
+
+{% block beforeContent %}
+<div class="top-page-links">
+  <a href="{{ backLink }}" class="govuk-back-link" data-id="risk-address">Back to summary</a>
+</div>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-l govuk-!-padding-top-0 h1-gap">
+          Rivers and the sea: understand your flood risk
+        </h1>
+      </div>
+    </div>
+  
+    <nav aria-label="Pages with more detail on this service" class="gem-c-contents-list govuk-!-margin-bottom-3"
+      role="navigation">
+      <ol class="gem-c-contents-list__list">
+        {% if surfaceWaterIsFirst %}
+        {% include 'partials/flagged/nav-sw.njk' %}
+        {% endif %}
+        {% include 'partials/flagged/nav-rs.njk' %}
+        {% if not surfaceWaterIsFirst %}
+        {% include 'partials/flagged/nav-sw.njk' %}
+        {% endif %}
+        {% include 'partials/flagged/nav-gw.njk' %}
+        </ol>
+    </nav>
+  
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        <h2 class="govuk-heading-m">Yearly chance of flooding</h2>
+        <p class="govuk-body">The yearly chance of flooding from rivers and the sea is:
+          <strong class="govuk-tag govuk-tag--{{ riversSeaRiskStyle }} label-mod-depth">
+            <span>{{ riverAndSeaRisk }}</span>
+          </strong>
+        </p>
+        {% include 'partials/floodRatings.html' %}
+  
+        <h2 class="govuk-heading-m">See a map of rivers and sea flood risk</h2>
+        
+        <p class="govuk-body"><a class="govuk-link" href="/map?easting={{easting}}&northing={{northing}}&map=RiversOrSea"
+            previewlistener="true">View a rivers and
+            sea map</a> for information on where any flood water might spread to (extent).</p>
+            
+        <h2 class="govuk-heading-m">What you can do</h2>
+
+        {% if riverAndSeaRisk !== 'Very low' %}
+        <p class="govuk-body">It's a good idea to check your flood risk regularly because the information may change.
+        </p>
+        <p class="govuk-body">You can also:</p>
+        <ul class="govuk-list--bullet">
+          <li class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/sign-up-for-flood-warnings"
+              previewlistener="true">sign up
+              to receive flood warnings by phone, text or email</a></li>
+          <li class="govuk-body">read about <a class="govuk-link" href="https://www.gov.uk/prepare-for-flooding"
+              previewlistener="true">how
+              to prepare yourself and your property</a></li>
+  
+        </ul>
+        {% else %}
+        <p class="govuk-body">It's a good idea to check your flood risk regularly because the information may change.</p>
+        <p class="govuk-body">You can also read about <a href="https://www.gov.uk/prepare-for-flooding">how to prepare yourself and your property</a>.</p>
+        {% endif %}
+
+        <hr
+          class="govuk-section-break govuk-section-break--m govuk-section-break--visible  govuk-!-margin-top-6 govuk-!-margin-bottom-3">
+  
+        <nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+          {% if surfaceWaterIsFirst %}
+          <div class="govuk-pagination__prev">
+            <a class="govuk-link govuk-pagination__link" href="/surface-water" rel="prev" previewlistener="true">
+              <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg"
+                height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+                <path
+                  d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z">
+                </path>
+              </svg>
+              <span class="govuk-pagination__link-title">Previous</span><span class="govuk-visually-hidden">:</span>
+              <span class="govuk-pagination__link-label">Surface water</span></a>
+          </div>
+          <div class="govuk-pagination__next">
+            <a class="govuk-link govuk-pagination__link" href="/ground-water" rel="next"
+              previewlistener="true"> <svg class="govuk-pagination__icon govuk-pagination__icon--next"
+                xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false"
+                viewBox="0 0 15 13">
+                <path
+                  d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z">
+                </path>
+              </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+              <span class="govuk-pagination__link-label">Groundwater and reservoirs</span></a>
+          </div>
+          {% else %}
+          <div class="govuk-pagination__next">
+            <a class="govuk-link govuk-pagination__link" href="/surface-water" rel="next"
+              previewlistener="true"> <svg class="govuk-pagination__icon govuk-pagination__icon--next"
+                xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false"
+                viewBox="0 0 15 13">
+                <path
+                  d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z">
+                </path>
+              </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+              <span class="govuk-pagination__link-label">Surface water</span></a>
+          </div>
+          {% endif %}
+          </nav>
+      </div>
+{% endblock %}

--- a/node/risk-app/server/views/surface-water.html
+++ b/node/risk-app/server/views/surface-water.html
@@ -1,0 +1,115 @@
+{% extends 'layout.html' %}
+
+{% set pageTitle = "Surface water: understand your flood risk" %}
+{% set currentpage = "surface-water" %}
+
+{% block head %}
+{{ super() }}
+<link href="{{ assetPath }}/stylesheets/risk-data.css" rel="stylesheet" />
+<link href="{{ assetPath }}/stylesheets/rivers-and-sea.css" rel="stylesheet" />
+{% endblock %}
+
+{% block beforeContent %}
+<div class="top-page-links">
+  <a href="{{ backLink }}" class="govuk-back-link" data-id="risk-address">Back to summary</a>
+</div>
+{% endblock %}
+
+{% block content %}
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l govuk-!-padding-top-0 h1-gap">
+        Surface water: understand your flood risk
+      </h1>
+    </div>
+  </div>   
+    
+  <nav aria-label="Pages with more detail on this service" class="gem-c-contents-list govuk-!-margin-bottom-3"
+  role="navigation">
+  <ol class="gem-c-contents-list__list">
+    {% if surfaceWaterIsFirst %}
+    {% include 'partials/flagged/nav-sw.njk' %}
+    {% endif %}
+    {% include 'partials/flagged/nav-rs.njk' %}
+    {% if not surfaceWaterIsFirst %}
+    {% include 'partials/flagged/nav-sw.njk' %}
+    {% endif %}
+    {% include 'partials/flagged/nav-gw.njk' %}
+</ol>
+</nav>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <h2 class="govuk-heading-m">Yearly chance of flooding</h2>
+    <p class="govuk-body">The yearly chance of surface water flooding is:
+      <strong class="govuk-tag govuk-tag--{{ surfaceWaterStyle }} label-mod-depth">
+        <span>{{ surfaceWaterRisk }}</span>
+      </strong>
+    </p>
+    <p class="govuk-body">This information tells you the highest chance of flooding on the land 15 metres around a property.</p>
+    {% include 'partials/floodRatings.html' %}
+
+    <h2 class="govuk-heading-m">See a map of surface water flood risk</h2>
+
+    <p class="govuk-body"><a class="govuk-link" href="/map?easting={{easting}}&northing={{northing}}&map=SurfaceWater"
+        previewlistener="true">View a surface water map</a> for information on: </p>
+        <ul class="govuk-list--bullet govuk-body">
+          <li>where any flood water might spread to (extent)</li>
+          <li>how deep any flood water could be (depth)</li>
+          <li>the speed and direction of any flood water (velocity)</li>
+  
+        </ul>
+
+    <h2 class="govuk-heading-m">What you can do</h2>
+      <p class="govuk-body">It's a good idea to check your flood risk regularly because the information may change.</p>
+      <p class="govuk-body">You can also read about <a href="https://www.gov.uk/prepare-for-flooding">how to prepare yourself and your property</a>.</p>
+      <p class="govuk-body">Lead local flood authorities are responsible for managing flood risk from surface water. They may hold more detailed information.</p>
+      <p class="govuk-body">Your lead local flood authority is <strong>{{leadLocalFloodAuthority}}</strong>.</p>
+      
+    <hr
+      class="govuk-section-break govuk-section-break--m govuk-section-break--visible  govuk-!-margin-top-6 govuk-!-margin-bottom-3">
+
+    <nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+      {% if surfaceWaterIsFirst %}
+      <div class="govuk-pagination__next">
+        <a class="govuk-link govuk-pagination__link" href="/rivers-and-sea" rel="next"
+          previewlistener="true"> <svg class="govuk-pagination__icon govuk-pagination__icon--next"
+            xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false"
+            viewBox="0 0 15 13">
+            <path
+              d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z">
+            </path>
+          </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+          <span class="govuk-pagination__link-label">Rivers and the sea </span></a>
+      </div>
+      {% else %}
+      <nav class="govuk-pagination govuk-pagination--block" role="navigation" aria-label="results">
+        <div class="govuk-pagination__prev">
+          <a class="govuk-link govuk-pagination__link" href="/rivers-and-sea" rel="prev" previewlistener="true">
+            <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg"
+              height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+              <path
+                d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z">
+              </path>
+            </svg>
+            <span class="govuk-pagination__link-title">Previous</span><span class="govuk-visually-hidden">:</span>
+            <span class="govuk-pagination__link-label">Rivers and Sea</span></a>
+        </div>
+        <div class="govuk-pagination__next">
+          <a class="govuk-link govuk-pagination__link" href="/ground-water" rel="next"
+            previewlistener="true"> <svg class="govuk-pagination__icon govuk-pagination__icon--next"
+              xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false"
+              viewBox="0 0 15 13">
+              <path
+                d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z">
+              </path>
+            </svg> <span class="govuk-pagination__link-title">Next</span><span class="govuk-visually-hidden">:</span>
+            <span class="govuk-pagination__link-label">Groundwater and reservoirs</span></a>
+        </div>
+  {% endif %}
+    </nav>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
* Designs for risk summary that don't include NaFRA2 data

https://eaflood.atlassian.net/browse/LTFRI-1163

* Update additional rivers and the sea page

https://eaflood.atlassian.net/browse/LTFRI-1167

* Update additional surface water page

https://eaflood.atlassian.net/browse/LTFRI-1166

* Create additional groundwater and reservoir page

https://eaflood.atlassian.net/browse/LTFRI-1168

* Update main summary Intro text

https://eaflood.atlassian.net/jira/software/c/projects/LTFRI/boards/589?selectedIssue=LTFRI-1172

Update the content at the top of the summary page to improve the content to ensure that the users understand their floodrisk.

* Updated text and added drop down accordion with specified information

* Change summary to be controlled by feature-flag

* Make back to address selection page work

* Naviagation follows page order correctly