### PR TITLE
Remove unused config env var

### DIFF
--- a/node/risk-app/server/config.js
+++ b/node/risk-app/server/config.js
@@ -48,7 +48,6 @@ const schema = joi.object().keys({
   }),
   authcookie: {
     cookiepassword: joi.string().required(),
-    siteusername: joi.string().required(),
     sitepassword: joi.string().required(),
     secure: joi.boolean().default(true),
     defaultdestination: joi.string().default('')


### PR DESCRIPTION
The username cookie auth is no longer used and can be deleted.