### PR TITLE
Add caching to flood service calls

### DIFF
--- a/node/risk-app/package.json
+++ b/node/risk-app/package.json
@@ -17,7 +17,7 @@
     "test": "npm run test:lint && npm run test:jest",
     "test:jest": "jest --no-cache  --detectOpenHandles --runInBand --forceExit",
     "test:lint": "standard",
-    "test:watch": "npm run test -- --watch",
+    "test:watch": "jest --watch",
     "debug": "node --inspect-brk=0.0.0.0:9229 index.js",
     "pre-commit": "npm run test && lint-staged",
     "dev": "nodemon -L index.js"

--- a/node/risk-app/server/routes/search.js
+++ b/node/risk-app/server/routes/search.js
@@ -2,7 +2,6 @@ const joi = require('joi')
 const boom = require('@hapi/boom')
 const { postcodeRegex, redirectToHomeCounty } = require('../helpers')
 const config = require('../config')
-const floodService = require('../services/flood')
 const SearchViewModel = require('../models/search-view')
 const errors = require('../models/errors.json')
 const { captchaCheck } = require('../services/captchacheck')
@@ -10,7 +9,7 @@ const { defineBackLink } = require('../services/defineBackLink')
 
 const getWarnings = async (postcode, request) => {
   try {
-    let warnings = await floodService.findWarnings(postcode)
+    let warnings = await request.server.methods.floodService(postcode)
     if (warnings?.address === 'England') {
       warnings = {}
     }

--- a/node/risk-app/server/server-methods/__tests__/server-methods-disabled-cache.spec.js
+++ b/node/risk-app/server/server-methods/__tests__/server-methods-disabled-cache.spec.js
@@ -2,6 +2,7 @@ const STATUS_CODES = require('http2').constants
 const createServer = require('../../../server')
 const addressService = require('../../services/address')
 const riskService = require('../../services/risk')
+const floodService = require('../../services/flood')
 const { mockOptions, mockSearchOptions } = require('../../../test/mock')
 const defaultOptions = {
   method: 'GET',
@@ -11,6 +12,7 @@ const defaultOptions = {
 const x = 40.7128
 const y = -74.0060
 const radius = 15
+const location = 'WA4 1AB'
 
 jest.mock('../../services/flood')
 jest.mock('../../services/address')
@@ -124,6 +126,43 @@ describe('server methods', () => {
           riverAndSeaRisk: null,
           surfaceWaterRisk: 'Very Low',
           surfaceWaterSuitability: 'County to Town'
+        })
+      )
+    })
+
+    it('should not return cached flood service warnings as cache is disabled', async () => {
+      // Setting initial values
+      floodService.__updateReturnValue({
+        address: '',
+        floods: [],
+        severity: 5,
+        message: 'There are currently no flood warnings or alerts in force at this location.'
+      })
+      const response = await server.methods.floodService(location)
+
+      expect(response).toEqual(
+        expect.objectContaining({
+          address: '',
+          floods: [],
+          severity: 5,
+          message: 'There are currently no flood warnings or alerts in force at this location.'
+        })
+      )
+      floodService.__updateReturnValue({
+        address: '',
+        floods: [],
+        severity: 4,
+        message: 'There are currently no flood warnings or alerts in force at this location.'
+      })
+
+      const changedResponse = await server.methods.floodService(location)
+
+      expect(changedResponse).toEqual(
+        expect.objectContaining({
+          address: '',
+          floods: [],
+          severity: 4,
+          message: 'There are currently no flood warnings or alerts in force at this location.'
         })
       )
     })

--- a/node/risk-app/server/server-methods/__tests__/server-methods-enabled-cache.spec.js
+++ b/node/risk-app/server/server-methods/__tests__/server-methods-enabled-cache.spec.js
@@ -2,6 +2,7 @@ const STATUS_CODES = require('http2').constants
 const createServer = require('../..')
 const addressService = require('../../services/address')
 const riskService = require('../../services/risk')
+const floodService = require('../../services/flood')
 const mockConfig = require('../../__mocks__/config')
 const { mockOptions, mockSearchOptions } = require('../../../test/mock')
 const defaultOptions = {
@@ -12,6 +13,7 @@ const defaultOptions = {
 const x = 40.7128
 const y = -74.0060
 const radius = 15
+const location = 'WA4 1AB'
 
 jest.mock('../../services/flood')
 jest.mock('../../services/address')
@@ -126,6 +128,43 @@ describe('server methods', () => {
           riverAndSeaRisk: null,
           surfaceWaterRisk: 'Very Low',
           surfaceWaterSuitability: 'County to Town'
+        })
+      )
+    })
+
+    it('should return original cached flood service warnings', async () => {
+      // Setting initial values
+      floodService.__updateReturnValue({
+        address: '',
+        floods: [],
+        severity: 5,
+        message: 'There are currently no flood warnings or alerts in force at this location.'
+      })
+      const response = await server.methods.floodService(location)
+
+      expect(response).toEqual(
+        expect.objectContaining({
+          address: '',
+          floods: [],
+          severity: 5,
+          message: 'There are currently no flood warnings or alerts in force at this location.'
+        })
+      )
+      floodService.__updateReturnValue({
+        address: '',
+        floods: [],
+        severity: 4,
+        message: 'There are currently no flood warnings or alerts in force at this location.'
+      })
+
+      const changedResponse = await server.methods.floodService(location)
+
+      expect(changedResponse).toEqual(
+        expect.objectContaining({
+          address: '',
+          floods: [],
+          severity: 5,
+          message: 'There are currently no flood warnings or alerts in force at this location.'
         })
       )
     })

--- a/node/risk-app/server/server-methods/server-methods.js
+++ b/node/risk-app/server/server-methods/server-methods.js
@@ -1,5 +1,6 @@
 const { find } = require('../services/address')
 const { getByCoordinates } = require('../services/risk')
+const { findWarnings } = require('../services/flood')
 const config = require('../config')
 
 const cacheEnabled = config.cacheEnabled
@@ -21,6 +22,19 @@ const serverMethods = [
   {
     name: 'riskService',
     method: getByCoordinates,
+    options: cacheEnabled
+      ? {
+          cache: {
+            cache: 'server_cache',
+            expiresIn: 100 * 1000,
+            generateTimeout: 20000
+          }
+        }
+      : undefined
+  },
+  {
+    name: 'floodService',
+    method: findWarnings,
     options: cacheEnabled
       ? {
           cache: {


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/LTFRI/boards/589?selectedIssue=LTFRI-1255

Increase client-side download speeds by adding caching to the flood service