### PR TITLE
remove 'warning' text from holding comment

### DIFF
--- a/node/risk-app/server/views/risk.html
+++ b/node/risk-app/server/views/risk.html
@@ -38,7 +38,6 @@
         <div class="govuk-warning-text">
           <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
           <strong class="govuk-warning-text__text">
-            <span class="govuk-warning-text__assistive">Warning</span>
             {% for comment in holdingComments %}
             <div class="{{ 'govuk-!-margin-bottom-4' if not loop.last }}">{{ comment }}</div>
             {% endfor %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1347

Holding comment warning title needs to be removed.