### PR TITLE
Remove 'Risk' from map pages

### DIFF
--- a/node/risk-app/package-lock.json
+++ b/node/risk-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "risk-app",
-  "version": "4.3.0",
+  "version": "4.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "risk-app",
-      "version": "4.3.0",
+      "version": "4.5.0",
       "license": "ISC",
       "dependencies": {
         "@airbrake/node": "^2.1.8",

--- a/node/risk-app/server/views/partials/map-page/key/rivers-and-sea.html
+++ b/node/risk-app/server/views/partials/map-page/key/rivers-and-sea.html
@@ -22,7 +22,7 @@
                   <rect class="high-symbol risk-colour-square" x="5" y="5"></rect>
                 </svg>
               </span>
-              <span id="risk-severity">High risk</span>
+              <span id="risk-severity">High</span>
               <span class="risk-context">More than 3.3% chance each year</span>
             </span>
 
@@ -34,7 +34,7 @@
                   <rect class="medium-symbol risk-colour-square" x="5" y="5"></rect>
                 </svg>
               </span>
-              Medium risk
+              Medium
               <span class="risk-context">Between 1% and 3.3% chance each year</span>
             </span>
 
@@ -46,7 +46,7 @@
                   <rect class="low-symbol risk-colour-square" x="5" y="5"></rect>
                 </svg>
               </span>
-              Low risk
+              Low
               <span class="risk-context">Between 0.1% and 1% chance each year</span>
             </span>
 
@@ -57,7 +57,7 @@
                   <rect class="very-low-symbol risk-colour-square" x="5" y="5"></rect>
                 </svg>
               </span>
-              Very low risk
+              Very low
               <span class="risk-context">Less than 0.1% chance each year</span>
             </span>
           </div>

--- a/node/risk-app/server/views/partials/map-page/key/surface-water.html
+++ b/node/risk-app/server/views/partials/map-page/key/surface-water.html
@@ -22,7 +22,7 @@
                   <rect class="high-symbol risk-colour-square" x="5" y="5"></rect>
                 </svg>
               </span>
-              <span id="risk-severity">High risk</span>
+              <span id="risk-severity">High</span>
               <span class="risk-context">More than 3.3% chance each year</span>
             </span>
 
@@ -34,7 +34,7 @@
                   <rect class="medium-symbol risk-colour-square" x="5" y="5"></rect>
                 </svg>
               </span>
-              Medium risk
+              Medium
               <span class="risk-context">Between 1% and 3.3% chance each year</span>
             </span>
 
@@ -46,7 +46,7 @@
                   <rect class="low-symbol risk-colour-square" x="5" y="5"></rect>
                 </svg>
               </span>
-              Low risk
+              Low
               <span class="risk-context">Between 0.1% and 1% chance each year</span>
             </span>
 

--- a/node/risk-app/server/views/surface-water.html
+++ b/node/risk-app/server/views/surface-water.html
@@ -58,8 +58,6 @@
         <ul class="govuk-list--bullet govuk-body">
           <li>where any flood water might spread to (extent)</li>
           <li>how deep any flood water could be (depth)</li>
-          <li>the speed and direction of any flood water (velocity)</li>
-  
         </ul>
 
     <h2 class="govuk-heading-m">What you can do</h2>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/LTFRI-1370

Remove the word risk from multiple map pages and also remove a bullet point from the Surface Water flood risk page.