### PR TITLE
Remove 'risk' from depth and velocity maps

### DIFF
--- a/node/risk-app/server/views/partials/map-page/map-controls.html
+++ b/node/risk-app/server/views/partials/map-page/map-controls.html
@@ -70,7 +70,7 @@
             <input class="risk-radio govuk-radios__input govuk-radios__inputs scenario-radio-button" id="risk-radio-high-depth"
               name="scenarios-depth" type="radio" value="{{maps.categories[1].maps[1].ref}}" checked="">
             <label class="govuk-label govuk-radios__label" for="risk-radio-high-depth">
-              <strong class="scenario-heading">High risk</strong>
+              <strong class="scenario-heading">High</strong>
               <span class="risk-context-v3">3.3% chance each year</span>
             </label>
           </div>
@@ -78,7 +78,7 @@
             <input class="risk-radio govuk-radios__input govuk-radios__inputs scenario-radio-button" id="risk-radio-medium-depth"
               name="scenarios-depth" type="radio" value="{{maps.categories[1].maps[3].ref}}">
             <label class="govuk-label govuk-radios__label" for="risk-radio-medium-depth">
-              <strong class="scenario-heading">Medium risk</strong>
+              <strong class="scenario-heading">Medium</strong>
               <span class="risk-context-v3">1% chance each year</span>
             </label>
           </div>
@@ -86,8 +86,7 @@
             <input class="risk-radio govuk-radios__input govuk-radios__inputs scenario-radio-button" id="risk-radio-low-depth"
               name="scenarios-depth" type="radio" value="{{maps.categories[1].maps[5].ref}}">
             <label class="govuk-label govuk-radios__label" for="risk-radio-low-depth">
-              <strong class="scenario-heading">Low
-                risk</strong>
+              <strong class="scenario-heading">Low</strong>
               <span class="risk-context-v3">0.1% chance each year</span>
             </label>
           </div>
@@ -119,7 +118,7 @@
               name="scenarios-velocity" type="radio"
               value="{{maps.categories[1].maps[2].ref}}" checked="">
             <label class="govuk-label govuk-radios__label" for="risk-radio-high-velocity">
-              <strong class="scenario-heading">High risk</strong>
+              <strong class="scenario-heading">High</strong>
               <span class="risk-context-v3">3.3% chance each year</span>
             </label>
           </div>
@@ -129,7 +128,7 @@
               name="scenarios-velocity" type="radio"
               value="{{maps.categories[1].maps[4].ref}}">
             <label class="govuk-label govuk-radios__label" for="risk-radio-medium-velocity">
-              <strong class="scenario-heading">Medium risk</strong>
+              <strong class="scenario-heading">Medium</strong>
               <span class="risk-context-v3">1% chance each year</span>
             </label>
           </div>
@@ -139,8 +138,7 @@
               name="scenarios-velocity" type="radio"
               value="{{maps.categories[1].maps[6].ref}}">
             <label class="govuk-label govuk-radios__label" for="risk-radio-low-velocity">
-              <strong class="scenario-heading">Low
-                risk</strong>
+              <strong class="scenario-heading">Low</strong>
               <span class="risk-context-v3">0.1% chance each year</span>
             </label>
           </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/LTFRI/boards/589?selectedIssue=LTFRI-1409

Risk needs to be removed from surface depth and velocity maps so that the content is consistent.